### PR TITLE
Update Incremental hom search to work for patterns with AttrVars

### DIFF
--- a/src/incremental/Incremental.jl
+++ b/src/incremental/Incremental.jl
@@ -165,14 +165,21 @@ end
 function good_overlap(subobj, h, I_R)
   S = acset_schema(dom(h))
   L = codom(subobj)
-  new_mat = Dict(k=>Set{Int}() for k in types(S))
-  for k in types(S)
-    v = h[k]
-    ϕ, ψ = k ∈ ob(S) ? (identity, identity) : (AttrVar, x-> x isa AttrVar ? x.val : x)
-    for i in ϕ.(parts(dom(h), k))
-      fᵢ = v(i)
-      if fᵢ ∉ collect(I_R[k])
-        push!(new_mat[k], ψ(subobj[k](i)))
+  # Parts of L which are mapped to newly added material via partial map
+  new_mat = Dict(k=>Set{Int}() for k in types(S)) 
+  for k in ob(S)
+    for i in parts(dom(h), k)
+      hᵢ = h[k](i)
+      if hᵢ ∉ collect(I_R[k])
+        push!(new_mat[k], subobj[k](i))
+      end
+    end
+  end
+  for k in attrtypes(S)
+    for i in AttrVar.(parts(dom(h), k))
+      hᵢ = h[k](i)
+      if hᵢ isa AttrVar && subobj[k](i) isa AttrVar && hᵢ.val ∉ collect(I_R[k])
+        push!(new_mat[k], subobj[k](i).val)
       end
     end
   end

--- a/src/incremental/Incremental.jl
+++ b/src/incremental/Incremental.jl
@@ -242,13 +242,15 @@ overlap which has already been calculated between L and Rᵢ.
 """
 function addition!(hset::IncCCHomSet, i::Int, rmap::ACSetTransformation, 
                    update::ACSetTransformation)
-  X, L, new_matches, new_keys = codom(rmap), hset.pattern, Dict{Int, ACSetTransformation}(), Pair{Int,Int}[]
   S = acset_schema(hset.pattern)
   # Push forward old matches
   for idx in 1:length(hset)
     hset.match_vect[idx] = Dict(
       k => m ⋅ update for (k, m) in pairs(hset.match_vect[idx]))
   end
+
+  # Find newly-introduced matches
+  X, L, new_matches, new_keys = codom(rmap), hset.pattern, Dict{Int, ACSetTransformation}(), Pair{Int,Int}[]
 
   push!(hset.match_vect, new_matches)
   old_stuff = Dict(o => setdiff(parts(X,o), collect(rmap[o])) for o in ob(S))
@@ -269,7 +271,7 @@ function addition!(hset::IncCCHomSet, i::Int, rmap::ACSetTransformation,
         if h ∈ values(new_matches)
           error("Duplicating work $h") 
         else 
-          @info "NEW from $subL\n$mapR"
+          # @info "NEW from $subL\n$mapR"
           new_key = length(hset) => length(new_keys)+1
           push!(hset.key_vect, new_key)
           push!(new_keys, new_key)
@@ -298,7 +300,7 @@ function deletion!(hset::IncCCHomSet, f::ACSetTransformation)
         delete!(hset.key_dict, idx=>idx′)
         push!(deleted, idx=>idx′)
       else 
-        dic[idx] = m
+        dic[idx′] = m′
       end
     end
   end

--- a/src/schedules/Poly.jl
+++ b/src/schedules/Poly.jl
@@ -180,7 +180,7 @@ Base.haskey(t::BTree, xs::Vector{WireVal}) = haskey(t.result_cache, xs)
 
 """Grow a tree and return the result."""
 function (t::BTree)(ks::Vector{WireVal}; kw...)
-  haskey(t, ks) && println("WARNING: REPEAT KEY")
+  haskey(t, ks) && @debug "WARNING: REPEAT KEY"
   old..., new = ks # ks cannot be empty
   isempty(old) || haskey(t, old) || t(old) # recursively compute earlier subsequences
   S = get_state(t, old)

--- a/src/schedules/Queries.jl
+++ b/src/schedules/Queries.jl
@@ -52,7 +52,7 @@ and purported new agent. (the new agent is the first argument to the constraint)
     Query(n,sa,a,ret;constraint=constraint)
   """ 
   Span Aₒ<-•->Aₙ relates old agent shape to new agent shape, such that the 
-  new agent Aₙ->X makes the square commute. If constraint is nontrivial, this 
+  new agent Aₙ->X makes the square commute. If `constraint` is nontrivial, this 
   constraint is added to it.
 
        rgt₂
@@ -63,7 +63,7 @@ and purported new agent. (the new agent is the first argument to the constraint)
   """
   function Query(a::Span, n::Symbol=:Query, ret=nothing; constraint=Trivial)
     in_shape, agent_shape = codom.([left(a),right(a)])
-    cg = @acset CGraph begin V=4; E=4; Elabel=1; src=[1,1,2,3]; tgt=[2,3,4,4]
+    cg = @acset CGraph begin V=4; E=4; src=[1,1,2,3]; tgt=[2,3,4,4]
       vlabel=[apex(a), in_shape, agent_shape, nothing]
       elabel=[a...,2,1]
     end

--- a/test/incremental/Incremental.jl
+++ b/test/incremental/Incremental.jl
@@ -27,7 +27,7 @@ A_rule = Rule(id(e), homomorphism(e, A); monic=true)
 
 # Empty edge case
 hset = IncHomSet(Graph(), [A_rule.R], Graph(3)); 
-@test length(hset.matches) == 1
+@test length(matches(hset)) == 1
 
 # Single connected component pattern
 start = @acset Graph begin V=3; E=3; src=[1,2,3]; tgt=[2,3,3] end

--- a/test/incremental/Incremental.jl
+++ b/test/incremental/Incremental.jl
@@ -28,19 +28,40 @@ A_rule = Rule(id(e), homomorphism(e, A); monic=true)
 # Empty edge case
 hset = IncHomSet(Graph(), [A_rule.R], Graph(3)); 
 @test length(matches(hset)) == 1
+@test only(keys(hset)) == (1=>1)
+@test hset[1] == hset[1=>1]
 
 # Single connected component pattern
 start = @acset Graph begin V=3; E=3; src=[1,2,3]; tgt=[2,3,3] end
 hset = IncHomSet(ee, [A_rule.R], start);
-rewrite!(hset, A_rule, homomorphisms(e, start)[2])
+del, add = rewrite!(hset, A_rule, homomorphisms(e, start)[2])
+@test isempty(del)
+@test length(add) == 6
 @test validate(hset)
 rewrite!(hset, A_rule)
 @test validate(hset)
+@test length.(hset.match_vect) == [3, 6, 8]
+@test !haskey(hset, 2=>7)
+@test haskey(hset, 3=>7)
+@test hset[3=>8] == hset[17]
 
 # Multiple connected components in pattern
 hset = IncHomSet(ee ⊕ e, [A_rule.R], start);
-rewrite!(hset, A_rule, homomorphisms(e, start)[2])
+
+@test haskey(hset, [1=>2, 1=>2])
+@test !haskey(hset, [2=>2, 1=>2])
+@test length(keys(hset)) == 9
+@test hset[[1=>3,1=>3]] == hset[9]
+
+del, add = rewrite!(hset, A_rule, homomorphisms(e, start)[2])
+
+@test isempty(del)
+
+@test length.(hset.ihs[1].match_vect) == [3,6]
+@test length.(hset.ihs[2].match_vect) == [3,3]
+@test length(add) == 6*(3+3) + (3+6)*3
 @test validate(hset)
+
 @test Set(matches(hset)) == Set(homomorphisms(ee ⊕ e, state(hset)))
 rewrite!(hset, A_rule)
 @test validate(hset)

--- a/test/incremental/Incremental.jl
+++ b/test/incremental/Incremental.jl
@@ -54,6 +54,15 @@ hset = IncHomSet(ee, [homomorphism(e, tri)], X);
 addition!(hset, 1, omap)
 @test validate(hset)
 
+# Multiple connected components 
+hset = IncHomSet(Graph(1) ⊕ e, [A_rule.R], start);
+rewrite!(hset, A_rule, homomorphisms(e, start)[2])
+@test validate(hset)
+rewrite!(hset, A_rule)
+@test validate(hset)
+@test length(keys(hset)) == 45
+
+
 # Weighted Graph
 const WG′ = WeightedGraph{Bool}
 e, ee = path_graph.(WG′, 2:3)
@@ -90,6 +99,7 @@ end
 
 rewrite!(hset, A_rule)
 @test validate(hset)
+
 
 ## DDS 
 #-----


### PR DESCRIPTION
Some changes to Incremental hom search were needed in order to make the process work with ACSets with concrete values as well as variables.

This depends on a modification to Catlab which allows for subobject enumeration of ACSets with variables: https://github.com/AlgebraicJulia/Catlab.jl/pull/887