### PR TITLE
New pushout complement for AttrVars

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -9,7 +9,7 @@ using CompTime
 using Catlab
 using Catlab.CategoricalAlgebra.FinSets: IdentityFunction, VarSet
 using Catlab.CategoricalAlgebra.Chase: extend_morphism, extend_morphism_constraints
-using Catlab.CategoricalAlgebra.CSets: unpack_diagram, type_components, abstract_attributes
+using Catlab.CategoricalAlgebra.CSets: unpack_diagram, type_components, abstract_attributes, var_reference
 import ..FinSets: pushout_complement, can_pushout_complement, id_condition
 import ACSets: acset_schema
 import Catlab.CategoricalAlgebra.FinSets: predicate
@@ -19,7 +19,7 @@ import Catlab.CategoricalAlgebra: is_natural, Slice, SliceHom, components,
 using ACSets.DenseACSets: attrtype_type, datatypes, constructor
 import ACSets: sparsify
 import Base: getindex
-using DataStructures: OrderedSet
+using DataStructures: OrderedSet, DefaultDict, IntDisjointSets, find_root!
 using StructEquality
 
 # Morphism search 
@@ -100,6 +100,47 @@ function check_pb(f,g,f_,g_)
   end 
 end
 
+# Non-monotonicity
+##################
+
+"""
+Every morphism induces a partition of the parts of the domain. This function 
+finds every nontrivial partition (size greater than one element) for the objects
+of the schema.
+"""
+fibers(f::ACSetTransformation) = 
+  Dict(o => fibers(f[o]) for o in ob(acset_schema(dom(f))))
+
+function fibers(f::FinFunction)
+  dic = DefaultDict{Int,Vector{Int}}(()->Int[])
+  for v in dom(f)
+    push!(dic[f(v)], v)
+  end
+  filter(xs->length(xs)>1, collect(values(dic)))
+end
+
+unions!(i::IntDisjointSets, xs::Vector{Int}) = if length(xs) > 1 
+  [union!(i, x, y) for (x,y) in zip(xs, xs[2:end])]
+end
+
+getvalue(a::AttrVar) = a.val
+
+"""Further induced equations between AttrVars, given a specific match morphism"""
+function var_eqs(l::ACSetTransformation, m::ACSetTransformation)
+  I, L = dom(l), codom(l)
+  S = acset_schema(L)
+  eq_I = Dict(a => IntDisjointSets(nparts(I, a)) for a in attrtypes(S))
+  for (o, xss) in pairs(fibers(m)) # match induces equivalence of ob parts in L
+    for xsₗ in xss
+      xsᵢ = Vector{Int}(vcat(preimage.(Ref(l[o]), xsₗ)...))
+      for (f, _, at) in attrs(S; from=o)
+        unions!(eq_I[at], getvalue.(filter(x -> x isa AttrVar, I[xsᵢ, f])))
+      end
+    end
+  end
+  eq_I
+end
+
 # Pushout complement
 ####################
 
@@ -111,45 +152,53 @@ this method will raise an error. If the dangling condition fails, the resulting
 C-set will be only partially defined. To check all these conditions in advance,
 use the function [`can_pushout_complement`](@ref).
 
-Because Subobject does not work well with AttrVars, a correction is made
+In the absence of AttrVars, K is a subobject of G. But we want to be able to 
+change the value of attributes. So any variables in I are not concretized by 
+the I->K map. However, AttrVars may be merged together if `m: L -> G` merges 
+parts together.
 """
 function pushout_complement(pair::ComposablePair{<:ACSet, <:TightACSetTransformation})
-  p1,p2 = pair 
-  I,G = dom(p1), codom(p2)
+  l, m = pair 
+  I, G = dom(l), codom(m)
   S = acset_schema(I)
+  all(at->nparts(G, at)==0, attrtypes(S)) || error("Cannot rewrite with AttrVars in G")
   # Compute pushout complements pointwise in FinSet.
-  components = NamedTuple(Dict([o=>pushout_complement(ComposablePair(p1[o],p2[o])) 
-                                for o in types(S)]))
-  k_components, g_components = map(first, components), map(last, components)
+  components = NamedTuple(Dict(map(ob(S)) do o 
+      o => pushout_complement(ComposablePair(l[o], m[o]))
+  end))
+  k_components = Dict{Symbol,Any}(pairs(map(first, components)))
+  g_components = Dict{Symbol,Any}(pairs(map(last, components)))
 
   # Reassemble components into natural transformations.
-  g = hom(Subobject(G, NamedTuple(Dict(o=>g_components[o] for o in ob(S)))))
+  g = hom(Subobject(G, NamedTuple(Dict(o => g_components[o] for o in ob(S)))))
   K = dom(g)
-  
-  for at in attrtypes(S)
-    add_parts!(K, at, codom(k_components[at]).n)
-  end
 
-  for (a, d, at) in attrs(S)
-    # force k to be natural
-    for p in parts(I, d)
-      K[k_components[d](p),a] = k_components[at](I[p, a])
-    end
-    # force g to be natural 
-    for p in parts(K, d)
-      gval = G[g_components[d](p), a]
-      preim = preimage(g_components[at], gval)
-      if !isempty(preim) && gval isa AttrVar
-        K[p,a] = AttrVar(only(preim))
+  var_eq = var_eqs(l, m) # equivalence class of attrvars
+
+  for at in attrtypes(S)
+    eq = var_eq[at]
+    roots = unique(find_root!.(Ref(eq), 1:length(eq)))
+    add_parts!(K, at, length(roots))
+    k_components[at] = map(parts(I, at)) do pᵢ
+      attrvar = AttrVar(findfirst(==(find_root!(eq, pᵢ)), roots))
+      for (a, d, _) in attrs(S; to=at)
+        for p in incident(I, AttrVar(pᵢ), a)
+          K[k_components[d](p), a] = attrvar
+        end
       end
+      attrvar
     end
-  end 
+    T = Union{AttrVar, attrtype_type(G, at)}
+    g_components[at] = Vector{T}(map(parts(K, at)) do v
+      f, o, val = var_reference(K, at, v)
+      G[g_components[o](val), f]
+    end)
+  end
 
   k = ACSetTransformation(I, K; k_components...)
   g = ACSetTransformation(K, G; g_components...)
-
-  force(compose(k,g)) == force(compose(p1,p2)) || error("Square doesn't commute")
-  is_natural(k) || error("k unnatural")
+  force(compose(k,g)) == force(compose(l, m)) || error("Square doesn't commute")
+  is_natural(k) || error("k unnatural $k")
   is_natural(g) || error("g unnatural")
   return ComposablePair(k, g)
 end
@@ -260,16 +309,6 @@ dangling_condition(pair::ComposablePair{<:DynamicACSet}) = let S = acset_schema(
   end
   results
 end
-
-# n_src = parts(codom(m), @ct(src_obj)) # BIG
-# unmatched_vals = setdiff(n_src, collect(m[@ct(src_obj)]))
-# unmatched_tgt = [codom(m)[x,@ct(morph)] for x in unmatched_vals]
-# for unmatched_val in setdiff(n_src, collect(m[@ct(src_obj)]))  # G/m(L) src
-#   unmatched_tgt = codom(m)[unmatched_val,@ct morph]
-#   if unmatched_tgt in dels[@ct(tgt_obj)]
-#     push!(results, (@ct(morph), unmatched_val, unmatched_tgt))
-#   end
-# end
 
 # Subobjects
 ############

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -138,7 +138,7 @@ function var_eqs(l::ACSetTransformation, m::ACSetTransformation)
       end
     end
   end
-  eq_I
+  return eq_I
 end
 
 # Pushout complement

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -46,37 +46,6 @@ function pushout_complement(pair::ComposablePair{<:FinSet{Int}})
   return ComposablePair(k, g)
 end
 
-"""
-This may not be the actual pushout complement in the relevant (Kleisli) category
-
-      l
-    L ← I
-  m ↓   ↓ k
-    G ← K
-      g
-
-"""
-function pushout_complement(pair::ComposablePair{<:VarSet{T}}) where {T}
-  l, m = pair
-  lm = compose(l,m)
-  I, G = dom(l), codom(m)
-  # Initialize I -> K with image of composite l⋅m
-  image_lm = unique([lm(AttrVar(i)) for i in I])
-  
-  # Additionally, any vars not matched by m should be matched by g
-  unmatched = setdiff(AttrVar.(G), collect(m))
-  K = FinSet(length(image_lm) + length(unmatched))
-
-  # Construct I -> K 
-  ik = VarFunction{T}([AttrVar(findfirst(==(lm(AttrVar(i))), image_lm)) 
-                       for i in I], FinSet(length(K)))
-  # Construct K -> G 
-  kg = VarFunction{T}(Union{T,AttrVar}[
-    [lm(AttrVar(findfirst(==(AttrVar(k)), collect(ik)))) 
-     for k in 1:length(image_lm)]..., unmatched...], FinSet(length(G)))
-  return ComposablePair(ik, kg)
-end
-
 can_pushout_complement(pair::ComposablePair{<:FinSet{Int}}) =
   all(isempty, id_condition(pair))
 

--- a/src/rewrite/DPO.jl
+++ b/src/rewrite/DPO.jl
@@ -3,8 +3,11 @@ module DPO
 using Catlab.CategoricalAlgebra
 
 using ...CategoricalAlgebra.CSets
+import ...CategoricalAlgebra.CSets: var_eqs, pushout_complement
 using ..Utils
-import ..Utils: rewrite_match_maps
+import ..Utils: rewrite_match_maps, check_match_var_eqs
+
+using DataStructures: find_root!
 
 """    rewrite_match_maps(r::Rule{:DPO}, m)
 Apply a DPO rewrite rule (given as a span, L<-I->R) to a ACSet
@@ -24,5 +27,44 @@ function rewrite_match_maps(r::Rule{:DPO}, m; check::Bool=false)
   rh, kh = pushout(r.R, ik) 
   Dict(:ik=>ik, :kg=>kg, :rh=>rh, :kh=>kh)
 end
+
+pushout_complement(r::Rule{:DPO}, m::ACSetTransformation) = 
+  pushout_complement(left(r), m)
+
+var_eqs(r::Rule{:DPO}, m::ACSetTransformation) = var_eqs(left(r), m)
+
+"""
+A match may be invalid because two variables (which are to be assigned different
+values via the I -> R map) are identified (due to merging via the I->L map, 
+which morally ought be monic but is not for AttrVars). We can check this before
+computing the pushout to make sure that we will not get an inconsistent result 
+when trying to compute it. This requires executing the custom exprs of the 
+rewrite rule, so we may wish to build in the ability to skip this step if that 
+is computationally intensive.
+"""
+function check_match_var_eqs(r::Rule{:DPO}, m::ACSetTransformation)
+  eqs = var_eqs(r, m)
+  I = dom(left(r))
+  S = acset_schema(I)
+  errs = []
+  for at in attrtypes(S)
+    roots = find_root!.(Ref(eqs[at]), 1:length(eqs[at]))
+    for root in unique(roots)
+      elems = findall(==(root), roots)
+      if length(elems) > 1 # potential for conflict
+        res = map(AttrVar.(elems)) do elem
+          rval = right(r)[at](elem)
+          rval isa AttrVar || return rval
+          r.exprs[at][rval.val](collect(m[at]))
+        end
+        length(unique(res)) == 1 || push!(errs, "$at: inconsistent $elems↦$res")
+      end
+    end
+  end
+  errs
+end
+
+"""Ignore for other categories"""
+check_match_var_eqs(::Rule{:DPO}, m) = []
 
 end # module 

--- a/src/rewrite/DPO.jl
+++ b/src/rewrite/DPO.jl
@@ -3,7 +3,7 @@ module DPO
 using Catlab.CategoricalAlgebra
 
 using ...CategoricalAlgebra.CSets
-import ...CategoricalAlgebra.CSets: var_eqs, pushout_complement
+import ...CategoricalAlgebra.CSets: var_eqs
 using ..Utils
 import ..Utils: rewrite_match_maps, check_match_var_eqs
 
@@ -21,15 +21,12 @@ This works for any type that implements `pushout_complement` and `pushout`
 """
 function rewrite_match_maps(r::Rule{:DPO}, m; check::Bool=false)
   if check
-    can_pushout_complement(r.L, m) || error("Can't pushout complement $r\n$m")
+    can_pushout_complement(left(r), m) || error("Can't pushout complement $r\n$m")
   end
-  ik, kg = pushout_complement(r.L, m)  
-  rh, kh = pushout(r.R, ik) 
+  ik, kg = pushout_complement(left(r), m)  
+  rh, kh = pushout(right(r), ik) 
   Dict(:ik=>ik, :kg=>kg, :rh=>rh, :kh=>kh)
 end
-
-pushout_complement(r::Rule{:DPO}, m::ACSetTransformation) = 
-  pushout_complement(left(r), m)
 
 var_eqs(r::Rule{:DPO}, m::ACSetTransformation) = var_eqs(left(r), m)
 
@@ -61,7 +58,7 @@ function check_match_var_eqs(r::Rule{:DPO}, m::ACSetTransformation)
       end
     end
   end
-  errs
+  return errs
 end
 
 """Ignore for other categories"""

--- a/src/rewrite/Utils.jl
+++ b/src/rewrite/Utils.jl
@@ -163,6 +163,11 @@ function can_match(r::Rule{T}, m; initial=Dict()) where T
     if !isempty(gc)
       return ("Gluing conditions failed", gc)
     end
+
+    meq = check_match_var_eqs(r, m)
+    if !isempty(meq)
+      return ("Induced attrvar equation failed", meq)
+    end
   end
 
   for (nᵢ, N) in enumerate(r.conditions)
@@ -280,4 +285,6 @@ Perform a rewrite (with a supplied match morphism) and return result.
 rewrite_match(r::AbsRule, m; kw...) =
   codom(get_expr_binding_map(r, m, rewrite_match_maps(r, m; kw...)))
 
+
+function check_match_var_eqs end # implement in DPO.jl
 end # module

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -30,22 +30,12 @@ end
 const LSet = LFinSetType{Symbol}
 
 I = @acset LSet begin X=1; D=1; f=[AttrVar(1)] end
-G = @acset LSet begin X=2; D=2; f=[:x,:y] end
+G = @acset LSet begin X=2; f=[:x,:y] end
 f = homomorphism(I,G)
 
 kg = last(pushout_complement(id(I),f))
-@test dom(kg) == @acset LSet begin X=2; D=3; f=[AttrVar(1),:y] end
-@test collect(kg[:D]) == [:x, AttrVar.(1:2)...]
-
-I = @acset LSet begin X=1; D=1; f=[AttrVar(1)] end
-G = @acset LSet begin X=2; D=2; f=AttrVar.(1:2) end
-f = homomorphisms(I,G)[2]
-kg = last(pushout_complement(id(I),f))
-
-I = @acset LSet begin X=1; D=1; f=[AttrVar(1)] end
-G = @acset LSet begin X=2; D=2; f=[:x,:x] end
-f = homomorphism(I,G)
-kg = last(pushout_complement(id(I),f))
+@test dom(kg) == @acset LSet begin X=2; D=1; f=[AttrVar(1),:y] end
+@test collect(kg[:D]) == [:x]
 
 # Slices 
 ########

--- a/test/rewrite/DPO.jl
+++ b/test/rewrite/DPO.jl
@@ -304,6 +304,7 @@ rule = Rule(l, r; monic=[:E], freevar=true)
 
 # Rewriting with induced equations between AttrVars in the rule
 #--------------------------------------------------------------
+
 @present SchFoo(FreeSchema) begin X::Ob; D::AttrType; f::Attr(X,D) end
 @acset_type AbsFoo(SchFoo)
 const Foo = AbsFoo{Bool}
@@ -319,5 +320,17 @@ rule = Rule(homomorphism(I, L; monic=[:X]), homomorphism(I, R; monic=[:X]))
 
 res = rewrite(rule, L)
 @test is_isomorphic(res, R)
+
+# Now with arbitrary functions
+
+rule = Rule(I; expr=(D=[((x₁, x₂),) -> x₁ && x₂, ((x₁, x₂),) -> x₁ ≤ x₂],))
+
+# We can match (1,2) and (2,1) no matter what because those impose no constraints
+# (1,1) and (2,2) do unify the variables of the rule, so it is only a valid 
+# match if the two expressions evaluate to the same value. Because ⊥∧⊥ ≠ ⊥⟹⊥
+# (whereas ⊤∧⊤ = ⊤⟹⊤), the only match where both X's are mapped to a single 
+# value is the case where they are mapped to the one with the attribute ⊤.
+@test collect.(getindex.(components.(get_matches(rule, R)), :X)) == [[1,2],[2,1],[2,2]]
+
 
 end # module 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,17 +77,17 @@ end
 # Schedules 
 ##########
 
-@testset "Schedules" begin
+@testset "Schedules: Poly" begin
   include("schedules/Poly.jl")
 end
 
-@testset "Schedules" begin
+@testset "Schedules: Eval" begin
   include("schedules/Eval.jl")
 end
 
 # Incremental hom search
 ########################
 
-@testset "Schedules" begin
+@testset "Incremental" begin
   include("incremental/Incremental.jl")
 end


### PR DESCRIPTION
This PR redoes how we handle AttrVars for pushout complements in light of https://github.com/AlgebraicJulia/AlgebraicRewriting.jl/issues/53

The computation is no longer handled pointwise. Although perhaps we can develop a clean understanding of what *should* happen in terms of pushout complements in a Kleisli category or in the machinery described by [this blog post](https://blog.algebraicjulia.org/post/2023/06/varacsets/), for now there is just intuition guided by some concrete examples.

Additional checks are needed to see if a match is valid because, if the match is not monic, it could be possible that two variables (which are mapped to different values in `I -> R`) are identified with each other. 

This is a breaking change because we no longer allow rewriting ACSets which themselves have variables (the rules, of course, still have variables, as well as the intermediate state `K` in between the initial and final state of a rewrite).