### PR TITLE
add presentation data to Migration 

### DIFF
--- a/benchmark/Agents.jl
+++ b/benchmark/Agents.jl
@@ -192,7 +192,8 @@ const hom = homomorphism
   (Sheep, Wolf)::Ob
   sheep_loc::Hom(Sheep, V); wolf_loc::Hom(Wolf, V)
   Eng::AttrType
-  countdown::Attr(V, Eng); sheep_eng::Attr(Sheep, Eng); wolf_eng::Attr(Wolf, Eng)
+  countdown::Attr(V, Eng); 
+  sheep_eng::Attr(Sheep, Eng); wolf_eng::Attr(Wolf, Eng)
 end
 
 @present TheoryWS′ <: TheoryWS begin
@@ -210,10 +211,8 @@ F = Migrate(
   Dict(:Sheep => :Wolf, :Wolf => :Sheep),
   Dict([:sheep_loc => :wolf_loc, :wolf_loc => :sheep_loc,
     :sheep_eng => :wolf_eng, :wolf_eng => :sheep_eng,
-    :countdown => :countdown]), WS)
-F2 = Migrate(
-  Dict(x => x for x in Symbol.(TheoryWS.generators[:Ob])),
-  Dict(x => x for x in Symbol.(TheoryWS.generators[:Hom])), WS′; delta=false)
+    :countdown => :countdown]), TheoryWS, WS)
+F2 = Migrate(TheoryWS, WS, TheoryWS′, WS′; delta=false)
 
 #=
 Create an n × n grid with periodic boundary conditions. Edges in each cardinal

--- a/docs/literate/game_of_life.jl
+++ b/docs/literate/game_of_life.jl
@@ -76,10 +76,8 @@ and obtain a state of the world with coordinates (the canonical way to do this
 is to assign "variables" for the values of the coordinates).
 =#
 
-idₒ = Dict(x => x for x in Symbol.(generators(SchLife, :Ob)))
-idₘ = Dict(x => x for x in Symbol.(generators(SchLife, :Hom)))
-F = Migrate(idₒ, idₘ, LifeCoords; delta=false); # adds coordinates
-F⁻¹ = DeltaMigration(FinFunctor(idₒ, idₘ, SchLife, SchLifeCoords)); # removes coordinates
+F = Migrate(SchLifeCoords, LifeCoords; delta=false); # adds coordinates
+# F⁻¹ = DeltaMigration(FinFunctor(idₒ, idₘ, SchLife, SchLifeCoords)); # removes coordinates
 
 # # Helper functions
 
@@ -173,7 +171,7 @@ visualization function.
 =#
 
 
-function view_life(X::Life, pth=tempname(); star=nothing)
+function view_life_graph(X::Union{Life,LifeCoords}, pth=tempname(); star=nothing)
   pg = PropertyGraph{Any}(; prog="neato", graph=Dict(),
     node=Dict(:shape => "circle", :style => "filled", :margin => "0"),
     edge=Dict(:dir => "none", :minlen => "1"))
@@ -193,7 +191,7 @@ function view_life(X::Life, pth=tempname(); star=nothing)
   G
 end;
 
-view_life(migrate(Life,  init, F⁻¹))
+view_life_graph(init)
 
 
 #=
@@ -203,12 +201,12 @@ in the next time step.
 =#
 Next() = @acset Life begin V = 1; Next = 1; next = 1 end;
 
-view_life(Next())
+view_life_graph(Next())
 
 # We also want to refer to a vertex which is alive in the current time step
 
 Curr() = @acset Life begin V = 1; Curr = 1; curr = 1 end;
-view_life(Curr())
+view_life_graph(Curr())
 
 # We also want these where we have a morphism incoming from a vertex. 
 to_next() = homomorphism(Life(1), Next());
@@ -227,10 +225,10 @@ function living_neighbors(n::Int; alive=false)
   X
 end
 
-view_life(living_neighbors(3))
+view_life_graph(living_neighbors(3))
 
 # We can control whether the central cell is itself alive or not
-view_life(living_neighbors(3; alive=true))
+view_life_graph(living_neighbors(3; alive=true))
 
 
 # # Rules 
@@ -322,7 +320,7 @@ view_sched(L)
 # Make an initial state
 G = make_grid([1 0 1 0 1; 0 1 0 1 0; 0 1 0 1 0; 1 0 1 0 1; 1 0 1 0 1])
 
-view_life(migrate(Life,  G, F⁻¹))
+view_life_graph(G)
 
 # (or, viewed in plaintext)
 

--- a/docs/literate/lotka_volterra.jl
+++ b/docs/literate/lotka_volterra.jl
@@ -126,7 +126,7 @@ F = Migrate(
   Dict(:Sheep => :Wolf, :Wolf => :Sheep),
   Dict([:sheep_loc => :wolf_loc, :wolf_loc => :sheep_loc,
     :sheep_eng => :wolf_eng, :wolf_eng => :sheep_eng, :countdown => :countdown,
-    :sheep_dir => :wolf_dir, :wolf_dir => :sheep_dir,]), LV);
+    :sheep_dir => :wolf_dir, :wolf_dir => :sheep_dir,]), SchLV, LV);
 
 #=
 We ought to be able to take a state of the world (with no coordinate information)
@@ -134,9 +134,7 @@ and obtain a state of the world with coordinates (the canonical way to do this
 is to assign "variables" for the values of the coordinates).
 =#
 
-F2 = Migrate(
-  Dict(x => x for x in Symbol.(SchLV.generators[:Ob])),
-  Dict(x => x for x in Symbol.(SchLV.generators[:Hom])), LV′; delta=false);
+F2 = Migrate(SchLV, LV, SchLV′, LV′; delta=false);
 
 # # Initializing and visualizing world states
 

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -450,16 +450,29 @@ end
 # Simple Δ migrations (or limited case Σ)
 #########################################
 
-"""To do: check if functorial"""
+"""TODO: check if functorial"""
 @struct_hash_equal struct Migrate
   obs::Dict{Symbol, Symbol}
   homs::Dict{Symbol, Symbol}
+  P1::Presentation
   T1::Type 
+  P2::Presentation
   T2::Type 
   delta::Bool 
-  Migrate(o,h,t1,t2=nothing; delta::Bool=true) = new(
-    Dict(collect(pairs(o))),Dict(collect(pairs(h))),t1,isnothing(t2) ? t1 : t2, delta)
 end 
+
+Migrate(s1::Presentation, t1::Type, s2=nothing, t2=nothing; delta=true) = 
+Migrate(Dict(x => x for x in Symbol.(generators(s1, :Ob))),
+        Dict(x => x for x in Symbol.(generators(s1, :Hom))),
+        s1, t1, s2, t2; delta)
+
+Migrate(o::Dict, h::Dict, s1::Presentation, t1::Type, s2=nothing, t2=nothing; 
+        delta::Bool=true) = Migrate(Dict(collect(pairs(o))),
+                                    Dict(collect(pairs(h))), s1, t1, 
+                                    isnothing(s2) ? s1 : s2, 
+                                    isnothing(t2) ? t1 : t2, 
+                                    delta)
+
 
 sparsify(d::Dict{V,<:ACSet}) where V = Dict([k=>sparsify(v) for (k,v) in collect(d)])
 sparsify(d::Dict{<:ACSet,V}) where V = Dict([sparsify(k)=>v for (k,v) in collect(d)])


### PR DESCRIPTION
The `Migration` object is in need of storing presentation information, so that it can have the equations at hand in case representables need to be computed. (As is the case in AlgebraicABMs). 