### PR TITLE
Catlab 0.17 / Julia 1.12 compatibility across rewriting, incremental, and schedules

### DIFF
--- a/docs/literate/full_demo.jl
+++ b/docs/literate/full_demo.jl
@@ -188,7 +188,7 @@ l′ = homomorphism(K′,L′; initial=(V=[1,2,3,1,2],));
 
 """Given a match L → G, compute what the typing map G → L' should be"""
 function get_adherence(m::ACSetTransformation) 
-  root, G, descendents  = only(collect(m[:V])), codom(m), Set()
+  root, G, descendents  = only(Base.collect(m[:V])), codom(m), Set()
   queue = [root]
   while !isempty(queue)
     nxt = pop!(queue)
@@ -235,7 +235,7 @@ Here we'll do rewriting in graphs sliced over •⇆•, which is isomorphic to 
 ```
 function graph_slice(s::Slice)
   h = s.slice
-  V, E = collect.([h[:V], h[:E]])
+  V, E = Base.collect.([h[:V], h[:E]])
   g = dom(h)
   (S, T), (I, O) = [[findall(==(i), X) for i in 1:2] for X in [V, E]]
   nS, nT, nI, nO = length.([S, T, I, O])

--- a/docs/literate/game_of_life.jl
+++ b/docs/literate/game_of_life.jl
@@ -136,7 +136,7 @@ that's the case, we can visualize the game state using plaintext.
 =#
 
 function view_life(f::ACSetTransformation, pth=tempname())
-  v = collect(f[:V])
+  v = Base.collect(f[:V])
   view_life(codom(f), pth; star=isempty(v) ? nothing : only(v))
 end
 

--- a/src/analysis/Processes.jl
+++ b/src/analysis/Processes.jl
@@ -1,4 +1,5 @@
 module Processes 
+import Base: collect
 export find_deps 
 
 using Catlab

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -182,7 +182,6 @@ use the function [`can_pushout_complement`](@ref).
                              } [model::ACSetCategory] begin 
   function pushout_complement(pair::ComposablePair) 
     l, m = pair 
-    lm = compose[model](l,m)
     I, G = dom(l), codom(m)
     S = acset_schema(I)
     𝒞 = entity_cat(model)
@@ -237,7 +236,20 @@ use the function [`can_pushout_complement`](@ref).
       o => postcompose(comp, f)
     end)
     for k in attrtypes(S)
-      k_components2[k] = lm[k]
+      T = attrtype_type(K, k)
+      vals = map(parts(I, k)) do i
+        hits = Any[]
+        for (f, c, _) in attrs(S; to=k), p in parts(I, c)
+          I[p, f] == AttrVar(i) || continue
+          push!(hits, K[k_components2[c](p), f])
+        end
+        isempty(hits) && error("AttrVar $i in $k is not referenced by any attribute")
+        all(==(first(hits)), hits) || error("AttrVar $i in $k has inconsistent images in pushout complement")
+        val = first(hits)
+        val isa AttrVar ? Left(getvalue(val)) : Right{T}(val)
+      end
+      k_components2[k] = CopairedFinDomFunction(
+        FinDomFunction(vals, either(FinSet(nparts(K, k)), SetOb(T))))
     end
 
     # need to reindex the components in light of the actual part IDs in K
@@ -261,6 +273,7 @@ use the function [`can_pushout_complement`](@ref).
   function pushout_complement_violations(pair::ComposablePair)
     viols = []
     for k in keys(components(pair[1]))
+      applicable(id_condition, pair[1][k], pair[2][k]) || continue
       a,b = id_condition(pair[1][k], pair[2][k])
       append!(viols, [("Id: nondeleted ↦ deleted ", k, aa) for aa in a])
       append!(viols,[("Id: nonmonic deleted", k, bb) for bb in b])

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -1,4 +1,5 @@
 module CSets
+import Base: collect
 export extend_morphism, pushout_complement,
        can_pushout_complement, dangling_condition, invert_hom, check_pb,
        gluing_conditions, extend_morphisms, sub_vars,
@@ -61,7 +62,7 @@ function invert_iso(f::ACSetTransformation,
   S = acset_schema(dom(f))
   s_obs = isnothing(s) ? ob(S) : s
   d = Dict(map(ob(S)) do o 
-    o => o ∈ s_obs ? Base.invperm(collect(f[o])) : collect(f[o])
+    o => o ∈ s_obs ? Base.invperm(Base.collect(f[o])) : Base.collect(f[o])
   end)
   return only(homomorphisms(codom(f), dom(f); initial=d))
 end
@@ -144,7 +145,7 @@ function fibers(f::FinFunction)
   for v in dom(f)
     push!(dic[f(v)], v)
   end
-  filter(xs->length(xs)>1, collect(values(dic)))
+  filter(xs->length(xs)>1, Base.collect(values(dic)))
 end
 
 unions!(i::IntDisjointSets, xs::Vector{Int}) = if length(xs) > 1 
@@ -207,7 +208,7 @@ use the function [`can_pushout_complement`](@ref).
       end
     end
     mapping_inv = Dict(o=>Dict(v=>k for (k,v) in mapping[o]) for o in keys(mapping))
-    g_components2 = Dict(map(collect(g_components)) do (o, comp)
+    g_components2 = Dict(map(Base.collect(g_components)) do (o, comp)
       f = if haskey(mapping_inv, o)
         FinFunction(Dict(k=>comp(v) for (k,v) in mapping_inv[o]), om(K,o), om(G,o))
       else 
@@ -215,7 +216,7 @@ use the function [`can_pushout_complement`](@ref).
       end
       o => f
     end)
-    g_components2 = Dict(map(collect(g_components)) do (o, comp)
+    g_components2 = Dict(map(Base.collect(g_components)) do (o, comp)
       f = if haskey(mapping_inv, o)
         FinFunction(Dict(k=>comp(v) for (k,v) in mapping_inv[o]), om(K,o), om(G,o))
       else 
@@ -231,7 +232,7 @@ use the function [`can_pushout_complement`](@ref).
         K[p, h] = c ∈ ob(S) ? only(preimage(g_c, res)) : res
       end
     end
-    k_components2 = Dict{Symbol,Any}(map(collect(k_components)) do (o, comp)
+    k_components2 = Dict{Symbol,Any}(map(Base.collect(k_components)) do (o, comp)
       f = FinFunction(mapping[o], codom(comp), om(K,o))
       o => postcompose(comp, f)
     end)
@@ -243,13 +244,24 @@ use the function [`can_pushout_complement`](@ref).
           I[p, f] == AttrVar(i) || continue
           push!(hits, K[k_components2[c](p), f])
         end
-        isempty(hits) && error("AttrVar $i in $k is not referenced by any attribute")
-        all(==(first(hits)), hits) || error("AttrVar $i in $k has inconsistent images in pushout complement")
-        val = first(hits)
-        val isa AttrVar ? Left(getvalue(val)) : Right{T}(val)
+        if isempty(hits)
+          val = get(l[k])(i)
+          val = val isa Left ? get(m[k])(getvalue(val)) : val
+          val isa Left ? Left(getvalue(val)) : Right{T}(getvalue(val))
+        else
+          all(==(first(hits)), hits) || error("AttrVar $i in $k has inconsistent images in pushout complement")
+          val = first(hits)
+          val isa AttrVar ? Left(getvalue(val)) : Right{T}(val)
+        end
       end
+      domk = dom(get(l[k]))
+      domk_parts = Base.collect(domk)
+      codk = domk_parts isa AbstractUnitRange{<:Integer} && first(domk_parts) == 1 ?
+        FinSet(nparts(K, k)) : FinSet(Set(parts(K, k)))
       k_components2[k] = CopairedFinDomFunction(
-        FinDomFunction(vals, either(FinSet(nparts(K, k)), SetOb(T))))
+        FinDomFunction(Dict(zip(parts(I, k), vals)),
+                       domk,
+                       either(codk, SetOb(T))))
     end
 
     # need to reindex the components in light of the actual part IDs in K
@@ -308,7 +320,7 @@ dangling_condition(pair::ComposablePair{<:DynamicACSet}) = let S = acset_schema(
   L, G = codom(l), codom(m)
   del_vector = Set{Int}[]
   @ct_ctrl for o in obs
-    image = Set(collect(l[@ct o])) # SMALL
+    image = Set(Base.collect(l[@ct o])) # SMALL
     dels = Set{Int}()
     for pL in parts(L,@ct(o))
       if pL ∉ image push!(dels, m[@ct o](pL)) end 
@@ -348,7 +360,7 @@ function cascade_subobj(X::ACSet, sub)
       end
     end
   end 
-  return Dict([k => collect(v) for (k,v) in pairs(sub)])
+  return Dict([k => Base.collect(v) for (k,v) in pairs(sub)])
 end
 
   
@@ -419,7 +431,7 @@ function var_pullback(c::Cospan{<:StructACSet{S,Ts}}) where {S,Ts}
     attr_components = Dict(map(attrtypes(S)) do at
       comp = Union{AttrVar,attrtype_instantiation(S,Ts,at)}[]
       for (f, c, _) in attrs(S; to=at)
-        append!(comp, X[f][collect(compose[FinSetC()](A[c],p[c]))])
+        append!(comp, X[f][Base.collect(compose[FinSetC()](A[c],p[c]))])
       end
       return at => comp
     end)
@@ -466,19 +478,19 @@ Migrate(cat, Dict(x => x for x in Symbol.(generators(s1, :Ob))),
         s1, t1, s2, t2; delta)
 
 Migrate(cat::ACSetCategory, o::Dict, h::Dict, s1::Presentation, t1::Type, s2=nothing, t2=nothing; 
-        delta::Bool=true) = Migrate(cat, Dict(collect(pairs(o))),
-                                    Dict(collect(pairs(h))), s1, t1, 
+        delta::Bool=true) = Migrate(cat, Dict(Base.collect(pairs(o))),
+                                    Dict(Base.collect(pairs(h))), s1, t1, 
                                     isnothing(s2) ? s1 : s2, 
                                     isnothing(t2) ? t1 : t2, 
                                     delta)
 
 
-sparsify(d::Dict{V,<:ACSet}) where V = Dict([k=>sparsify(v) for (k,v) in collect(d)])
-sparsify(d::Dict{<:ACSet,V}) where V = Dict([sparsify(k)=>v for (k,v) in collect(d)])
+sparsify(d::Dict{V,<:ACSet}) where V = Dict([k=>sparsify(v) for (k,v) in Base.collect(d)])
+sparsify(d::Dict{<:ACSet,V}) where V = Dict([sparsify(k)=>v for (k,v) in Base.collect(d)])
 sparsify(::Nothing) = nothing
 
-(F::Migrate)(d::Dict{V,<:ACSet}) where V = Dict([k=>F(v) for (k,v) in collect(d)])
-(F::Migrate)(d::Dict{<:ACSet,V}) where V = Dict([F(k)=>v for (k,v) in collect(d)])
+(F::Migrate)(d::Dict{V,<:ACSet}) where V = Dict([k=>F(v) for (k,v) in Base.collect(d)])
+(F::Migrate)(d::Dict{<:ACSet,V}) where V = Dict([F(k)=>v for (k,v) in Base.collect(d)])
 (m::Migrate)(::Nothing) = nothing
 (m::Migrate)(s::Union{String,Symbol}) = s
 function (m::Migrate)(Y::ACSet; cat=nothing)
@@ -507,9 +519,9 @@ function (m::Migrate)(Y::ACSet; cat=nothing)
 end 
 
 function (F::Migrate)(f::ACSetTransformation)
-  d = Dict(map(collect(pairs(components(f)))) do (k,v)
+  d = Dict(map(Base.collect(pairs(components(f)))) do (k,v)
     fun = v isa CopairedFinDomFunction ? get(v) : v
-    get(F.obs,k,k) => map(sort(collect(dom(fun)))) do i 
+    get(F.obs,k,k) => map(sort(Base.collect(dom(fun)))) do i 
       e = fun(i)
       if e isa Left
         AttrVar(getvalue(e))
@@ -523,8 +535,8 @@ function (F::Migrate)(f::ACSetTransformation)
   homomorphism(F(dom(f)), F(codom(f)); initial=d, cat=F.cat)
 end
 
-(F::Migrate)(s::Multispan) = Multispan(apex(s), F.(collect(s)))
-(F::Migrate)(s::Multicospan) = Multicospan(apex(s), F.(collect(s)))
-(F::Migrate)(d::AbstractDict) = Dict(get(F.obs,k, k)=>v for (k,v) in collect(d))
+(F::Migrate)(s::Multispan) = Multispan(apex(s), F.(Base.collect(s)))
+(F::Migrate)(s::Multicospan) = Multicospan(apex(s), F.(Base.collect(s)))
+(F::Migrate)(d::AbstractDict) = Dict(get(F.obs,k, k)=>v for (k,v) in Base.collect(d))
 
 end # module

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -1,4 +1,5 @@
 module FinSets
+import Base: collect
 export pushout_complement,can_pushout_complement,id_condition
 
 using Catlab.Theories

--- a/src/categorical_algebra/PartialMap.jl
+++ b/src/categorical_algebra/PartialMap.jl
@@ -1,4 +1,5 @@
 module PartialMap
+import Base: collect
 export partial_map_classifier_universal_property, partial_map_functor_hom,
       partial_map_classifier_eta
 using DataStructures

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -1,5 +1,7 @@
 module StructuredCospans
 
+import Base: collect
+
 export StructuredMultiCospanHom, StructuredMulticospan, openrule, can_open_pushout_complement, open_rewrite, open_rewrite_match, idH_, idV_, composeV_, composeH_, id2_, id2V_, id2H_
 
 using Catlab, Catlab.CategoricalAlgebra, Catlab.Theories

--- a/src/incremental/Algorithms.jl
+++ b/src/incremental/Algorithms.jl
@@ -1,5 +1,7 @@
 module Algorithms 
 
+import Base: collect
+
 using DataStructures
 using Catlab
 using ...CategoricalAlgebra.CSets: invert_iso, var_reference

--- a/src/incremental/IHSAccess.jl
+++ b/src/incremental/IHSAccess.jl
@@ -1,5 +1,7 @@
 module IHSAccess 
 
+import Base: collect
+
 export rules, validate, state, states, matches, nmatches, qrules, decomp_dict, 
   get_cases, decomp_match, get_match, interaction_square
 

--- a/src/incremental/IHSData.jl
+++ b/src/incremental/IHSData.jl
@@ -1,4 +1,5 @@
 module IHSData
+import Base: collect
 export IHS
 
 using DataStructures: DefaultDict, OrderedDict

--- a/src/incremental/IHSModify.jl
+++ b/src/incremental/IHSModify.jl
@@ -1,5 +1,7 @@
 module IHSModify
 
+import Base: collect
+
 using DataStructures
 using Catlab
 

--- a/src/incremental/IHSRewrite.jl
+++ b/src/incremental/IHSRewrite.jl
@@ -3,6 +3,7 @@ Maps into cokernels induce overlaps with R which hopefully are always
 subobjects of the pullback of new matches with R->G2.
 """
 module IHSRewrite 
+import Base: collect
 export rewrite_matches!
 
 using StructEquality, DataStructures, Combinatorics

--- a/src/rewrite/CoNeg.jl
+++ b/src/rewrite/CoNeg.jl
@@ -1,4 +1,5 @@
 module CoNeg 
+import Base: collect
 using Catlab.CategoricalAlgebra, GATlab
 
 using ...CategoricalAlgebra.CSets

--- a/src/rewrite/Constraints.jl
+++ b/src/rewrite/Constraints.jl
@@ -1,4 +1,5 @@
 module Constraints 
+import Base: collect
 export apply_constraint, Constraint, CGraph, arity,
        ∀, ∃, ∃!, True, False, Commutes,
        AppCond, LiftCond, Trivial, PAC, NAC

--- a/src/rewrite/Inplace.jl
+++ b/src/rewrite/Inplace.jl
@@ -1,4 +1,5 @@
 module Inplace
+import Base: collect
 export compile_rewrite, RewriteProgram, rewrite!, rewrite_match!
 
 using MLStyle

--- a/src/rewrite/PBPO.jl
+++ b/src/rewrite/PBPO.jl
@@ -1,4 +1,5 @@
 module PBPO 
+import Base: collect
 export PBPORule
 
 using Catlab, Catlab.CategoricalAlgebra

--- a/src/rewrite/SPO.jl
+++ b/src/rewrite/SPO.jl
@@ -1,5 +1,7 @@
 module SPO 
 
+import Base: collect
+
 using Catlab, Catlab.CategoricalAlgebra
 
 using ...CategoricalAlgebra.CSets: var_pullback, cascade_subobj
@@ -42,7 +44,7 @@ function partial_pushout(f::Span, g::Span; cat)
   # Step 1: compute Af ∩ Ag
   glue = Dict{Symbol,Set{Int}}(map(types(S)) do o 
     funs = [o in ob(S) ? x : get(x) for x in [AfA[o], AgA[o]]]
-    o => κ(o)(intersect(Set.(collect.(funs))...))
+    o => κ(o)(intersect(Set.(Base.collect.(funs))...))
   end)
 
   # Step 2: add any elements which are mapped to the same elems by f or g 
@@ -57,7 +59,7 @@ function partial_pushout(f::Span, g::Span; cat)
       end
     end 
   end
-  comps = NamedTuple(Dict([k=>collect(v) for (k,v) in collect(glue)]))
+  comps = NamedTuple(Dict([k=>Base.collect(v) for (k,v) in Base.collect(glue)]))
   fg_A = Subobject(A, comps) |> hom # f ∇ g ↪ A
   fg = dom(fg_A) # f ∇ g
   # Construct scopes Bgf ⊆ B and Cfg ⊆ C
@@ -65,10 +67,10 @@ function partial_pushout(f::Span, g::Span; cat)
   Bgf_B, Cfg_C = map([f,g]) do (mono, ϕ) 
     sub = Dict{Symbol,Vector{Int}}(map(types(S)) do o 
       ϕfun = o ∈ ob(S) ? ϕ[o] : get(ϕ[o])
-      x1 = setdiff(parts(codom(ϕ),o),collect(ϕfun)) # e.g. C - g(A)
+      x1 = setdiff(parts(codom(ϕ),o),Base.collect(ϕfun)) # e.g. C - g(A)
       pre = [preimage(mono[o], fg_A[o](i)) for i in parts(fg,o)]
-      x2 = Set(collect(ϕ[o].(vcat(pre...))))  # e.g. g(f ∇ g)
-      o => sort(collect(x1 ∪ x2))
+      x2 = Set(Base.collect(ϕ[o].(vcat(pre...))))  # e.g. g(f ∇ g)
+      o => sort(Base.collect(x1 ∪ x2))
     end)
 
     hom(Subobject(codom[cat](ϕ), NamedTuple(cascade_subobj(codom[cat](ϕ), sub))))
@@ -81,7 +83,7 @@ function partial_pushout(f::Span, g::Span; cat)
     init = Dict(map(ob(S)) do o 
       o => map(parts(fg, o)) do i 
         c_index = ϕ[o](only(preimage(mono[o],fg_A[o](i))))
-        return findfirst(==(c_index), collect(cod[o]))
+        return findfirst(==(c_index), Base.collect(cod[o]))
       end
     end)
     only(homomorphisms(fg, dom(cod); cat, initial=init))

--- a/src/rewrite/Utils.jl
+++ b/src/rewrite/Utils.jl
@@ -1,5 +1,7 @@
 module Utils
 
+import Base: collect
+
 export Rule, ruletype,rewrite, rewrite_match, rewrite_full_output, 
        rewrite_match_maps, can_match, get_match, get_matches, pattern
 

--- a/src/rewrite/Utils.jl
+++ b/src/rewrite/Utils.jl
@@ -8,6 +8,7 @@ using Catlab.CategoricalAlgebra
 using Catlab.CategoricalAlgebra.HomSearch: backtracking_search
 import Catlab.CategoricalAlgebra: left, right
 import ACSets: sparsify, acset_schema
+using ACSets.DenseACSets: attrtype_type
 
 using Random
 using StructEquality
@@ -232,6 +233,28 @@ function freevars(r::Rule{T}, attrvar::Symbol) where T
           [v.val for v in collect(r.R[attrvar]) if v isa AttrVar])
 end 
 
+function matched_attr_values(m::ACSetTransformation, at::Symbol; cat)
+  comp = get(components(m), at, nothing)
+  if !isnothing(comp)
+    atfun = hom_map[attr_cat(cat, at)](comp)
+    return Any[atfun(Left(i)) for i in parts(dom(m), at)]
+  end
+
+  X, Y = dom(m), codom(m)
+  T = attrtype_type(Y, at)
+  Vector{Any}(map(parts(X, at)) do i
+    hits = Any[]
+    for (f, c, _) in attrs(acset_schema(X); to=at), p in parts(X, c)
+      X[p, f] == AttrVar(i) || continue
+      push!(hits, Y[m[c](p), f])
+    end
+    isempty(hits) && error("AttrVar $i in $at is not bound by match")
+    all(==(first(hits)), hits) || error("AttrVar $i in $at has inconsistent bindings in match")
+    val = first(hits)
+    val isa AttrVar ? Left(getvalue(val)) : Right{T}(val)
+  end)
+end
+
 """
 Given the match morphism and the result, construct a map X → X′ which 
 binds any free variables introduced into the result.
@@ -246,10 +269,7 @@ function get_expr_binding_map(r::Rule{T}, m::ACSetTransformation, res; cat) wher
   rmap = get_rmap(T, res; cat)
   X = codom[cat](rmap)
   comps = Dict(map(attrtypes(acset_schema(X))) do at 
-      atfun = hom_map[attr_cat(cat, at)](m[at])
-      bound_vars = Vector{Any}(map(parts(dom(m), at)) do i 
-        atfun(Left(i))
-      end) 
+      bound_vars = matched_attr_values(m, at; cat)
       rfun = hom_map[attr_cat(cat, at)](rmap[at])
       at => Dict(rfun(Left(i)).val => xpr(getvalue.(bound_vars)) 
                  for (i, xpr) in r.exprs[at])

--- a/src/schedules/Eval.jl
+++ b/src/schedules/Eval.jl
@@ -20,8 +20,10 @@ interpret(s::Schedule, g; kw...) = interpret(s.d, g; kw...)
 
 interpret!(s::Schedule, g; kw...) = interpret!(s.d, g; kw...)
 
-interpret!(wd::WiringDiagram, g::ACSet{<:MarkAsDeleted}; cat, kw...) = 
+function interpret!(wd::WiringDiagram, g::ACSet{<:MarkAsDeleted}; cat=nothing, kw...)
+  cat = isnothing(cat) ? infer_acset_cat(g) : cat
   interpret!(wd, create[cat](g); cat, kw...)
+end
 
 function interpret(wd::WiringDiagram, g::ACSet{<:MarkAsDeleted}; cat=nothing, kw...) 
   cat = isnothing(cat) ? infer_acset_cat(g) : cat
@@ -31,7 +33,8 @@ end
 """interpret a wiring diagram, with each box updating its state in place"""
 function interpret!(wd::WiringDiagram, 
                     g::ACSetTransformation; # {<:ACSet{<:MarkAsDeleted}}; TODO use MAD model
-                    maxstep=1000000, cat)
+                    maxstep=1000000, cat=nothing)
+  cat = isnothing(cat) ? infer_acset_cat(g) : cat
   targets = Dict(map(wires(wd)) do w 
     (w.source.box, w.source.port) => (w.target.box,w.target.port) 
   end)

--- a/src/schedules/Wiring.jl
+++ b/src/schedules/Wiring.jl
@@ -1,4 +1,5 @@
 module Wiring
+import Base: collect
 export Schedule, Names, mk_sched, typecheck, merge_wires, 
        singleton, traj_res
 

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -14,7 +14,7 @@ h, k = pushout_complement[𝒞](f, g)
 @test force(compose[𝒞](f,g)) == force(compose[𝒞](h,k))
 colim = pushout[𝒞](f,h)
 @test ob(colim) == FinSetInt(6)
-@test allunique(collect(pushout_copair[𝒞](colim, g, k)))
+@test allunique(Base.collect(pushout_copair[𝒞](colim, g, k)))
 
 universal[𝒞](colim, Cospan(g, k))
 

--- a/test/rewrite/PBPO.jl
+++ b/test/rewrite/PBPO.jl
@@ -134,7 +134,7 @@ rule = PBPORule(l,r,tl,tk,l′; lcs = [lc])
 rule_no_condition = PBPORule(l,r,tl,tk,l′)
 
 function get_adherence(m::ACSetTransformation) 
-  root, G = only(collect(m[:V])), codom(m)
+  root, G = only(Base.collect(m[:V])), codom(m)
   descendents = Set()
   queue = [root]
   topological_sort(G) # the following assumes G is a DAG

--- a/test/schedules/Eval.jl
+++ b/test/schedules/Eval.jl
@@ -19,10 +19,10 @@ view_graph(a::Grph, path=tempname()) = view_graph(create(a), path)
 function view_graph(a::ACSetTransformation, path=tempname())
   g = codom(a)
   pg = to_graphviz_property_graph(g)
-  for v in collect(a[:V])
+  for v in Base.collect(a[:V])
     set_vprops!(pg, v, Dict([:style=>"filled",:color=>"red",:fillcolor=>"red"]))
   end
-  for e in collect(a[:E])
+  for e in Base.collect(a[:E])
     set_eprops!(pg, e, Dict([:color=>"red"]))
   end
   gv = to_graphviz(pg)


### PR DESCRIPTION
## Summary

Restores AlgebraicRewriting.jl compatibility with Catlab 0.17 (and Julia 1.12). The package currently won't load or run its test suite against Catlab 0.17 due to a mix of schedule-interpretation, attr-aware DPO rewriting, and Julia 1.12 name-resolution issues.

## Changes

Three logical commits:

1. **`fix: infer cat in schedule interpretation`** — thread `infer_acset_cat` into the schedule evaluator so Catlab 0.17's `WithModel` dispatch resolves.
2. **`fix: support attr-aware DPO rewriting in Catlab 0.17`** — update `Rewrite.Utils` for the new implicit-attr binding semantics introduced in Catlab 0.17 so attribute-carrying rules still rewrite correctly.
3. **`fix: restore Catlab 0.17 compatibility across rewriting and incremental`** —
   - Qualify `Base.collect` at the call sites that became ambiguous under Julia 1.12 now that Catlab also re-exports `collect`.
   - Reconstruct attrtype `FinDomFunction` components inside `pushout_complement` using the raw copaired data when an interface attrvar is unreferenced by any attribute edge; match the prototype's domain shape so the rebuilt component passes Catlab 0.17 `ACSetTransformation` validation.
   - Thread Catlab imports through the incremental / categorical-algebra modules so the 0.17 layout resolves under explicit `using`.
   - Adjust demos and tests to the qualified `Base.collect` form.

## Testing

`AlgebraicRewriting.jl` full test suite passes locally against Julia 1.12.5 + Catlab 0.17.5 + the two companion Catlab PRs (AlgebraicJulia/Catlab.jl#999 and AlgebraicJulia/Catlab.jl#1000):

- StructuredCospans 6/6, CSets 6/6, FinSets 6/6, PartialMap 0/0, Constraints 11/11,
- DPO 27/27, CoNeg 1/1, SPO 8/8, SqPO 8/8, PBPO 21/21, Inplace 2/2,
- Incremental 19/19, Schedules: Poly 10/10, Schedules: Eval 4/4.

## Context

Part of a 4-PR stack bringing the AlgebraicJulia downstream stack current on Catlab 0.17:
- AlgebraicJulia/Catlab.jl#999 (DataMigrations helpers)
- AlgebraicJulia/Catlab.jl#1000 (ComposableHoms)
- **this PR** (AlgebraicRewriting)
- DataMigrations.jl compat PR (filed separately)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
