### PR TITLE
Support Julia 1.12

### DIFF
--- a/docs/literate/full_demo.jl
+++ b/docs/literate/full_demo.jl
@@ -188,7 +188,7 @@ l′ = homomorphism(K′,L′; initial=(V=[1,2,3,1,2],));
 
 """Given a match L → G, compute what the typing map G → L' should be"""
 function get_adherence(m::ACSetTransformation) 
-  root, G, descendents  = only(collect(m[:V])), codom(m), Set()
+  root, G, descendents  = only(Base.collect(m[:V])), codom(m), Set()
   queue = [root]
   while !isempty(queue)
     nxt = pop!(queue)
@@ -235,7 +235,7 @@ Here we'll do rewriting in graphs sliced over •⇆•, which is isomorphic to 
 ```
 function graph_slice(s::Slice)
   h = s.slice
-  V, E = collect.([h[:V], h[:E]])
+  V, E = Base.collect.([h[:V], h[:E]])
   g = dom(h)
   (S, T), (I, O) = [[findall(==(i), X) for i in 1:2] for X in [V, E]]
   nS, nT, nI, nO = length.([S, T, I, O])

--- a/docs/literate/game_of_life.jl
+++ b/docs/literate/game_of_life.jl
@@ -136,7 +136,7 @@ that's the case, we can visualize the game state using plaintext.
 =#
 
 function view_life(f::ACSetTransformation, pth=tempname())
-  v = collect(f[:V])
+  v = Base.collect(f[:V])
   view_life(codom(f), pth; star=isempty(v) ? nothing : only(v))
 end
 

--- a/src/analysis/Processes.jl
+++ b/src/analysis/Processes.jl
@@ -46,7 +46,7 @@ function find_deps(seq::Vector{RWStep}; cat)
   hom = vcat([[left(s.g), right(s.g)] for s in seq]...)
   src = vcat([fill(i,2) for i in 1:n]...); # [1, 1, 2, 2, 3, 3, ..., n, n]
   tgt = [1,vcat([fill(i,2) for i in 2:n]...)...,n+1] # [1, 2, 2, ..., n, n, n+1]
-  hs  = collect(zip(hom, src, tgt))
+  hs  = Base.collect(zip(hom, src, tgt))
   clim = colimit[cat](BipartiteFreeDiagram(ob₁, ob₂, hs))
   clegs = legs(clim)
 
@@ -55,7 +55,7 @@ function find_deps(seq::Vector{RWStep}; cat)
   pres, del, cre = [Dict() for _ in 1:3]
   for o in Ob 
     pres[o], del[o], cre[o] = [[] for _ in 1:3]
-    img(f) = Set(collect(f[o])) # the image of a map
+    img(f) = Set(Base.collect(f[o])) # the image of a map
     for (i,s) in enumerate(seq)
       push!(pres[o], @withmodel cat (⋅) begin 
         img(left(s.rule) ⋅ s.match ⋅ clegs[i])

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -61,7 +61,7 @@ function invert_iso(f::ACSetTransformation,
   S = acset_schema(dom(f))
   s_obs = isnothing(s) ? ob(S) : s
   d = Dict(map(ob(S)) do o 
-    o => o ∈ s_obs ? Base.invperm(collect(f[o])) : collect(f[o])
+    o => o ∈ s_obs ? Base.invperm(Base.collect(f[o])) : Base.collect(f[o])
   end)
   return only(homomorphisms(codom(f), dom(f); initial=d))
 end
@@ -144,7 +144,7 @@ function fibers(f::FinFunction)
   for v in dom(f)
     push!(dic[f(v)], v)
   end
-  filter(xs->length(xs)>1, collect(values(dic)))
+  filter(xs->length(xs)>1, Base.collect(values(dic)))
 end
 
 unions!(i::IntDisjointSets, xs::Vector{Int}) = if length(xs) > 1 
@@ -208,7 +208,7 @@ use the function [`can_pushout_complement`](@ref).
       end
     end
     mapping_inv = Dict(o=>Dict(v=>k for (k,v) in mapping[o]) for o in keys(mapping))
-    g_components2 = Dict(map(collect(g_components)) do (o, comp)
+    g_components2 = Dict(map(Base.collect(g_components)) do (o, comp)
       f = if haskey(mapping_inv, o)
         FinFunction(Dict(k=>comp(v) for (k,v) in mapping_inv[o]), om(K,o), om(G,o))
       else 
@@ -216,7 +216,7 @@ use the function [`can_pushout_complement`](@ref).
       end
       o => f
     end)
-    g_components2 = Dict(map(collect(g_components)) do (o, comp)
+    g_components2 = Dict(map(Base.collect(g_components)) do (o, comp)
       f = if haskey(mapping_inv, o)
         FinFunction(Dict(k=>comp(v) for (k,v) in mapping_inv[o]), om(K,o), om(G,o))
       else 
@@ -232,7 +232,7 @@ use the function [`can_pushout_complement`](@ref).
         K[p, h] = c ∈ ob(S) ? only(preimage(g_c, res)) : res
       end
     end
-    k_components2 = Dict{Symbol,Any}(map(collect(k_components)) do (o, comp)
+    k_components2 = Dict{Symbol,Any}(map(Base.collect(k_components)) do (o, comp)
       f = FinFunction(mapping[o], codom(comp), om(K,o))
       o => postcompose(comp, f)
     end)
@@ -295,7 +295,7 @@ dangling_condition(pair::ComposablePair{<:DynamicACSet}) = let S = acset_schema(
   L, G = codom(l), codom(m)
   del_vector = Set{Int}[]
   @ct_ctrl for o in obs
-    image = Set(collect(l[@ct o])) # SMALL
+    image = Set(Base.collect(l[@ct o])) # SMALL
     dels = Set{Int}()
     for pL in parts(L,@ct(o))
       if pL ∉ image push!(dels, m[@ct o](pL)) end 
@@ -335,7 +335,7 @@ function cascade_subobj(X::ACSet, sub)
       end
     end
   end 
-  return Dict([k => collect(v) for (k,v) in pairs(sub)])
+  return Dict([k => Base.collect(v) for (k,v) in pairs(sub)])
 end
 
   
@@ -406,7 +406,7 @@ function var_pullback(c::Cospan{<:StructACSet{S,Ts}}) where {S,Ts}
     attr_components = Dict(map(attrtypes(S)) do at
       comp = Union{AttrVar,attrtype_instantiation(S,Ts,at)}[]
       for (f, c, _) in attrs(S; to=at)
-        append!(comp, X[f][collect(compose[FinSetC()](A[c],p[c]))])
+        append!(comp, X[f][Base.collect(compose[FinSetC()](A[c],p[c]))])
       end
       return at => comp
     end)
@@ -453,19 +453,19 @@ Migrate(cat, Dict(x => x for x in Symbol.(generators(s1, :Ob))),
         s1, t1, s2, t2; delta)
 
 Migrate(cat::ACSetCategory, o::Dict, h::Dict, s1::Presentation, t1::Type, s2=nothing, t2=nothing; 
-        delta::Bool=true) = Migrate(cat, Dict(collect(pairs(o))),
-                                    Dict(collect(pairs(h))), s1, t1, 
+        delta::Bool=true) = Migrate(cat, Dict(Base.collect(pairs(o))),
+                                    Dict(Base.collect(pairs(h))), s1, t1, 
                                     isnothing(s2) ? s1 : s2, 
                                     isnothing(t2) ? t1 : t2, 
                                     delta)
 
 
-sparsify(d::Dict{V,<:ACSet}) where V = Dict([k=>sparsify(v) for (k,v) in collect(d)])
-sparsify(d::Dict{<:ACSet,V}) where V = Dict([sparsify(k)=>v for (k,v) in collect(d)])
+sparsify(d::Dict{V,<:ACSet}) where V = Dict([k=>sparsify(v) for (k,v) in Base.collect(d)])
+sparsify(d::Dict{<:ACSet,V}) where V = Dict([sparsify(k)=>v for (k,v) in Base.collect(d)])
 sparsify(::Nothing) = nothing
 
-(F::Migrate)(d::Dict{V,<:ACSet}) where V = Dict([k=>F(v) for (k,v) in collect(d)])
-(F::Migrate)(d::Dict{<:ACSet,V}) where V = Dict([F(k)=>v for (k,v) in collect(d)])
+(F::Migrate)(d::Dict{V,<:ACSet}) where V = Dict([k=>F(v) for (k,v) in Base.collect(d)])
+(F::Migrate)(d::Dict{<:ACSet,V}) where V = Dict([F(k)=>v for (k,v) in Base.collect(d)])
 (m::Migrate)(::Nothing) = nothing
 (m::Migrate)(s::Union{String,Symbol}) = s
 function (m::Migrate)(Y::ACSet; cat=nothing)
@@ -494,9 +494,9 @@ function (m::Migrate)(Y::ACSet; cat=nothing)
 end 
 
 function (F::Migrate)(f::ACSetTransformation)
-  d = Dict(map(collect(pairs(components(f)))) do (k,v)
+  d = Dict(map(Base.collect(pairs(components(f)))) do (k,v)
     fun = v isa CopairedFinDomFunction ? get(v) : v
-    get(F.obs,k,k) => map(sort(collect(dom(fun)))) do i 
+    get(F.obs,k,k) => map(sort(Base.collect(dom(fun)))) do i 
       e = fun(i)
       if e isa Left
         AttrVar(getvalue(e))
@@ -510,8 +510,8 @@ function (F::Migrate)(f::ACSetTransformation)
   homomorphism(F(dom(f)), F(codom(f)); initial=d, cat=F.cat)
 end
 
-(F::Migrate)(s::Multispan) = Multispan(apex(s), F.(collect(s)))
-(F::Migrate)(s::Multicospan) = Multicospan(apex(s), F.(collect(s)))
-(F::Migrate)(d::AbstractDict) = Dict(get(F.obs,k, k)=>v for (k,v) in collect(d))
+(F::Migrate)(s::Multispan) = Multispan(apex(s), F.(Base.collect(s)))
+(F::Migrate)(s::Multicospan) = Multicospan(apex(s), F.(Base.collect(s)))
+(F::Migrate)(d::AbstractDict) = Dict(get(F.obs,k, k)=>v for (k,v) in Base.collect(d))
 
 end # module

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -35,13 +35,13 @@ this in advance, use [`can_pushout_complement`](@ref).
     l, m = pair
     I, L, G = dom(l), codom(l), codom(m)
     # Construct inclusion g: K ↪ G.
-    l_image = Set(collect(l))
+    l_image = Set(Base.collect(l))
     m_image = Set([ m(x) for x in L if x ∉ l_image ])
     g = FinFunction([x for x in G if x ∉ m_image], G)
     K = dom(g)
 
     # Construct morphism k: I → K using partial inverse of g.
-    g_inv = Dict{Int,Int}(zip(collect(g), K))
+    g_inv = Dict{Int,Int}(zip(Base.collect(g), K))
     k = FinFunction(Vector{Int}(map(I) do x
       y = m(l(x))
       get(g_inv, y) do; error("Identification failed for domain element $x") end
@@ -51,7 +51,7 @@ this in advance, use [`can_pushout_complement`](@ref).
   end
 
   pushout_complement_violations(p::ComposablePair) =
-    vcat(collect.(id_condition(p...))...)
+    vcat(Base.collect.(id_condition(p...))...)
 end
 
 @instance ThPushoutComplement{FinSetInt, CopairedFinDomFunction{T, Int, Int}
@@ -64,7 +64,7 @@ end
   end
 
   pushout_complement_violations(p::ComposablePair) =
-    vcat(collect.(id_condition(p...))...)
+    vcat(Base.collect.(id_condition(p...))...)
 
 end
 
@@ -107,7 +107,7 @@ this in advance, use [`can_pushout_complement`](@ref).
   end
 
   pushout_complement_violations(p::ComposablePair) =
-    vcat(collect.(id_condition(p...))...)
+    vcat(Base.collect.(id_condition(p...))...)
 
 end
 
@@ -127,7 +127,7 @@ We'll also assume that the map m: L+T->G+T is secretly just a map L->T (G=∅).
   end
 
   pushout_complement_violations(p::ComposablePair) =
-    vcat(collect.(id_condition(p...))...)
+    vcat(Base.collect.(id_condition(p...))...)
 
 end
 
@@ -145,7 +145,7 @@ Returns pair of iterators of
       item in G.
 """
 function id_condition(l::FinFunction, m::FinFunction)
-  l_image = Set(collect(l))
+  l_image = Set(Base.collect(l))
   l_imageᶜ = [ x for x in codom(l) if x ∉ l_image ]
   m_image = Set(map(m, l_imageᶜ))
   ((i for i in l_image if m(i) ∈ m_image),
@@ -156,7 +156,7 @@ end
 
 """ Kleisli composition """
 function id_condition(l::FinDomFunction, m::FinDomFunction)
-  l_image = Set(collect(l))
+  l_image = Set(Base.collect(l))
   l_imageᶜ = [ x for x in dom(m) if Left(x) ∉ l_image ]
   m_image = Set(map(m, l_imageᶜ))
   err1 = filter(l_image) do i

--- a/src/categorical_algebra/PartialMap.jl
+++ b/src/categorical_algebra/PartialMap.jl
@@ -80,19 +80,19 @@ function partial_map_functor_ob(x::StructCSet;
   # foreign keys
   d = DefaultDict{Symbol,Dict{Vector{Int},Int}}(()->Dict{Vector{Int},Int}())
 
-  hdata = collect(homs(S))
+  hdata = Base.collect(homs(S))
   for o in topo_obs(S)
     homs_cds = [(h,cd) for (h,d,cd) in hdata if d==o] # outgoing morphism data
     if isempty(homs_cds)
       d[o][Int[]] = add_part!(res, o)
     else
-      homs, cds = collect.(zip(homs_cds...))
+      homs, cds = Base.collect.(zip(homs_cds...))
       for c in Iterators.product([1:nparts(res,cd) for cd in cds]...)
-        d[o][collect(c)] = v = add_part!(res, o; Dict(zip(homs,c))...)
+        d[o][Base.collect(c)] = v = add_part!(res, o; Dict(zip(homs,c))...)
 
         # Forbid modifications which violate schema equations
         if !isnothing(pres) && !check_eqs(res, pres, o, v)
-          delete!(d[o], collect(c))
+          delete!(d[o], Base.collect(c))
           rem_part!(res, o, v)
         end
       end
@@ -116,10 +116,10 @@ function partial_map_functor_hom(f::ACSetTransformation;
   S = acset_schema(X)
   (d, _), (cd, cddict) = [partial_map_functor_ob(x; pres=pres) for x in [X,Y]]
   comps, mapping = Dict{Symbol,Vector{Int}}(), Dict()
-  hdata = collect(homs(S))
+  hdata = Base.collect(homs(S))
 
   for (k,v) in pairs(f.components)
-    mapping[k] = vcat(collect(v), [nparts(Y, k)+1]) # map extra val to extra
+    mapping[k] = vcat(Base.collect(v), [nparts(Y, k)+1]) # map extra val to extra
   end
 
   for o in topo_obs(S)
@@ -143,7 +143,7 @@ function partial_map_classifier_eta(x::StructCSet; cat,
     pres::Union{Nothing, Presentation}=nothing)::ACSetTransformation
   S = acset_schema(x)
   codom = partial_map_functor_ob(x; pres=pres)[1]
-  d = Dict([k=>collect(v) for (k,v) in pairs(id[cat](x).components)])
+  d = Dict([k=>Base.collect(v) for (k,v) in pairs(id[cat](x).components)])
   ACSetTransformation(x, codom; d...)
 end
 
@@ -169,7 +169,7 @@ function partial_map_classifier_universal_property(
     pres::Union{Nothing, Presentation}=nothing, check=false
     )::ACSetTransformation
   S = acset_schema(dom(m))
-  hdata   = collect(homs(S))
+  hdata   = Base.collect(homs(S))
   A, B    = codom[cat](m), codom[cat](f)
   ηB      = partial_map_classifier_eta(B; cat, pres=pres)
   Bdict   = partial_map_functor_ob(B; pres=pres)[2]
@@ -181,7 +181,7 @@ function partial_map_classifier_universal_property(
   # Get mapping of the known values
   for (o, fcomp) in pairs(components(f))
     unknown[o] = nparts(TB, o)
-    for (aval, fval) in zip(collect(m[o]), collect(fcomp))
+    for (aval, fval) in zip(Base.collect(m[o]), Base.collect(fcomp))
       fdata[o][aval] = fval
     end
   end

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -23,7 +23,7 @@ struct StructuredMultiCospanHom{L}
     length(m) == length(legs(t)) + 1 || error("bad # maps")
     𝒞 = get_ACS(L)
     ⋅(a,b) = force(compose[𝒞](a,b))
-    eq(f) = (dom(f), codom(f), [k=>collect(v) for (k,v) in pairs(components(f))])
+    eq(f) = (dom(f), codom(f), [k=>Base.collect(v) for (k,v) in pairs(components(f))])
     for (i,(s_leg, t_leg, st_map)) in enumerate(zip(legs(s), legs(t), m[2:end]))
       ms, mt = force(s_leg ⋅ m[1]), force(st_map ⋅ t_leg)
       dom(ms) == dom(mt) || error("domain error $(dom(ms)) $(dom(mt))")
@@ -80,10 +80,10 @@ function homomorphisms(pat::StructuredMulticospan{L},
   # Add leg data data to each ACset
   #--------------------------------
   for (Lname, lname, l) in zip(Ls, ls, legs(pat))
-    add_parts!(tpat, Lname, nparts(dom(l), V); Dict([lname => collect(l[V])])...)
+    add_parts!(tpat, Lname, nparts(dom(l), V); Dict([lname => Base.collect(l[V])])...)
   end
   for (Lname, lname, l) in zip(Ls, ls, legs(tgt))
-    add_parts!(ttgt, Lname, nparts(dom(l), V); Dict([lname => collect(l[V])])...)
+    add_parts!(ttgt, Lname, nparts(dom(l), V); Dict([lname => Base.collect(l[V])])...)
   end
 
   # Compute homomorphisms in alternate schema
@@ -187,7 +187,7 @@ function composeH_(f::openrule, g::openrule)::openrule
   𝒞 = get_ACS(L)
 
   # we only care about equality up to i/o behavior (== considers indexing)
-  non_indexed(x) = (dom(x), codom(x), collect.(values(components(x))))
+  non_indexed(x) = (dom(x), codom(x), Base.collect.(values(components(x))))
   non_indexed(λ.maps[end]) == non_indexed(χ.maps[2]) || error(
     "cannot horizontally compose")
   non_indexed(ρ.maps[end]) == non_indexed(ζ.maps[2]) || error(

--- a/src/incremental/Algorithms.jl
+++ b/src/incremental/Algorithms.jl
@@ -131,8 +131,8 @@ function good_merge_overlap(subobj::ACSetTransformation, h::ACSetTransformation,
   end
   all(isempty, values(merged_mat)) && return false # fail condition 1
   # parts of L which are sent to merged parts of R
-  L_merged = Dict(map(collect(pairs(merged_mat))) do (k, vs)
-    k => Set(map(collect(vs)) do v 
+  L_merged = Dict(map(Base.collect(pairs(merged_mat))) do (k, vs)
+    k => Set(map(Base.collect(vs)) do v 
       subobj[k](k ∈ ob(S) ? v : AttrVar(v))
     end)
   end)
@@ -169,7 +169,7 @@ function good_overlap(subobj::ACSetTransformation, h::ACSetTransformation,
 
   for k in ob(S)
     for p in parts(O, k)
-      h[k](p) ∈ collect(I_R[k]) || push!(new_mat[k], p)
+      h[k](p) ∈ Base.collect(I_R[k]) || push!(new_mat[k], p)
     end
   end
   for k in attrtypes(S)
@@ -179,13 +179,13 @@ function good_overlap(subobj::ACSetTransformation, h::ACSetTransformation,
     end
   end
   all(isempty, values(new_mat)) && return false # fail condition 1
-  L_new = Dict(map(collect(pairs(new_mat))) do (k, vs)
-    k => Set(map(collect(vs)) do v 
+  L_new = Dict(map(Base.collect(pairs(new_mat))) do (k, vs)
+    k => Set(map(Base.collect(vs)) do v 
       subobj[k](k ∈ ob(S) ? v : AttrVar(v))
     end)
   end)
   for k in ob(S)
-    for p in setdiff(parts(L, k), collect(subobj[k])) # for all old material
+    for p in setdiff(parts(L, k), Base.collect(subobj[k])) # for all old material
       for (f, _, cd) in homs(S; from=k) # for all things old material depends on
         cd == k && continue # TODO can we do this kind of filtering for, e.g. DDS?
         L[p, f] ∈ L_new[cd] && return false # fail condition 2
@@ -225,8 +225,8 @@ between two things which are themselves pattern-sized.
 function nac_overlap(nac, update::ACSetTransformation)
   N = codom(nac)
   Ob = ob(acset_schema(N))
-  L_parts_in_N = Dict(o=>Set(collect(nac.m[o])) for o in Ob)
-  non_deleted_X_parts = Dict(o=>Set(collect(update[o])) for o in Ob)
+  L_parts_in_N = Dict(o=>Set(Base.collect(nac.m[o])) for o in Ob)
+  non_deleted_X_parts = Dict(o=>Set(Base.collect(update[o])) for o in Ob)
   mostly_deleted_X = hom(~Subobject(update)) # the deleted stuff, and a bit more
   χ = dom(mostly_deleted_X)
   undeleted = Dict(map(Ob) do o 
@@ -345,8 +345,8 @@ Convert a morphism X → Ω into a subobject X'↣X, assuming that Ω was genera
 by Catlab's `subobject_classifier` function.
 """
 function to_subobj(f::ACSetTransformation)
-  Subobject(dom(f); Dict(map(collect(pairs(components(f)))) do (k, v)
-    k => findall(==(1), collect(v))
+  Subobject(dom(f); Dict(map(Base.collect(pairs(components(f)))) do (k, v)
+    k => findall(==(1), Base.collect(v))
   end)...)
 end
 
@@ -394,7 +394,7 @@ function is_combinatorially_monic(f::ACSetTransformation)
   S = acset_schema(dom(f))
   all(o -> is_monic(f[o]), ob(S)) || return false
   return all(attrtype(S)) do o 
-    attrimg = filter(v -> v isa AttrVar, collect(f[o]))
+    attrimg = filter(v -> v isa AttrVar, Base.collect(f[o]))
     length(attrimg) == length(unique(attrimg))
   end
 end
@@ -475,7 +475,7 @@ function all_epis(X::ACSet)
       end
     end
   end
-  return cheap_uncurry.(collect(values(epis)))
+  return cheap_uncurry.(Base.collect(values(epis)))
 end
 
 eq(x::Symbol) = Symbol("$(x)_eq")

--- a/src/incremental/IHSAccess.jl
+++ b/src/incremental/IHSAccess.jl
@@ -103,7 +103,7 @@ function matches(h::IHS, iₛ::Int, iₚ::Int)
   curr = h[iₛ, :curr]
   feet_matches = map(dom.(legs(colim))) do X
     map(cc_matches(h, iₛ, pattern_cc(h, X))) do match_id
-      cmps = Dict(map(collect(pairs(h[match_id, :match]))) do (k,v)
+      cmps = Dict(map(Base.collect(pairs(h[match_id, :match]))) do (k,v)
         rest = [updates[time][k] for time in (h[match_id, :match_time]+1):curr]
         k => foldl(compose[FinSetC()], [v; rest])
       end )
@@ -114,7 +114,7 @@ function matches(h::IHS, iₛ::Int, iₚ::Int)
   end
   map(Iterators.product(feet_matches...)) do combo
     @withmodel cat (universal, ⋅) begin 
-      force(h[iₚ, :pattern_iso] ⋅ universal(colim, Multicospan(S, collect(combo))))
+      force(h[iₚ, :pattern_iso] ⋅ universal(colim, Multicospan(S, Base.collect(combo))))
     end
   end
 end

--- a/src/incremental/IHSData.jl
+++ b/src/incremental/IHSData.jl
@@ -141,7 +141,7 @@ function to_datalog_json(db::IHS, JSON_FILE::String; rename=Dict())
     r_inv = invert_hom(db[qr, :r_quot]; monic=false) # R~ -> R
     l_inv = qrule ⋅ r_inv # L~ -> R
       
-    eqclasses = map(collect.(collect(db[qr, :profile][ob_name]))) do eqset 
+    eqclasses = map(Base.collect.(Base.collect(db[qr, :profile][ob_name]))) do eqset 
       sort(f[ob_name].(eqset))
     end
     quintuples = []
@@ -160,8 +160,8 @@ function to_datalog_json(db::IHS, JSON_FILE::String; rename=Dict())
       XL = db[elem, :decomp_elem_L]
       XR = db[elem, :decomp_elem_R]
       for int in lr_to_ints[XL=>XR]
-        hl = collect((db[int, :idata_iL] ⋅ l_inv)[ob_name])
-        hr = collect((db[int, :idata_iR] ⋅ r_inv)[ob_name])
+        hl = Base.collect((db[int, :idata_iL] ⋅ l_inv)[ob_name])
+        hr = Base.collect((db[int, :idata_iR] ⋅ r_inv)[ob_name])
         push!(quintuples, (;XG,XL,XR,hl,hr))
       end
     end

--- a/src/incremental/IHSModify.jl
+++ b/src/incremental/IHSModify.jl
@@ -168,7 +168,7 @@ function merge_profile(f::ACSetTransformation)
     for p in parts(X, o)
       push!(d[f[o](p)], p)
     end
-    o => Set(filter(e->length(e)>1, collect(values(d))))
+    o => Set(filter(e->length(e)>1, Base.collect(values(d))))
   end)
 end
 
@@ -222,7 +222,7 @@ function alt_decomps(gr, sos::Vector, esos, iₐ::Int)
     curr = pop!(queue)
     curr ∈ seen && continue 
     push!(seen, curr)
-    curr_v = sort(collect(curr))
+    curr_v = sort(Base.collect(curr))
 
     ob1 = dsos[[L for (_,_,L,_) in curr_v]]
     ob2 = dsos[[iₐ; [R for (_,_,_,R) in curr_v]]]

--- a/src/incremental/IHSRewrite.jl
+++ b/src/incremental/IHSRewrite.jl
@@ -162,7 +162,7 @@ function rewrite_bulk_monic_matches(ihs::IHS, m::Vector{<:ACSetTransformation},
       dom(σ) == codom(ihs[iₚ, :subobj]) || error("Bad")
       elems = incident(ihs, d, :decomp)
       ND = length(elems)
-      getindex.(Ref(ihs), elems, :decomp_elem_idx) == collect(1:ND) || error(
+      getindex.(Ref(ihs), elems, :decomp_elem_idx) == Base.collect(1:ND) || error(
         "Decomp out of order!")
       LRs = map(elems) do elem 
         (ihs[elem, :decomp_elem_L], ihs[elem, :decomp_elem_R] )

--- a/src/rewrite/CoNeg.jl
+++ b/src/rewrite/CoNeg.jl
@@ -7,7 +7,7 @@ import ..Utils: rewrite_match_maps
 import Catlab.CategoricalAlgebra: Subobject
 
 Subobject(X::ACSet, f::ACSetTransformation) = 
-  Subobject(X; Dict([k=>collect(vs) for (k,vs) in pairs(components(f))])...)
+  Subobject(X; Dict([k=>Base.collect(vs) for (k,vs) in pairs(components(f))])...)
 
 """    rewrite_match_maps(r::Rule{:CoNeg}, m)
 Apply a CoNegation rewrite rule (given as a span, L↩I->R) to a ACSet

--- a/src/rewrite/Constraints.jl
+++ b/src/rewrite/Constraints.jl
@@ -75,7 +75,7 @@ function merge_graphs(g1,g2)
   overlap_g = CGraph()
   p1, p2 = [Dict(:V=>Int[], :E=>Int[]) for _ in 1:2]
   # Merge vertices
-  for (v1,X) in filter(x->x[2] isa ACSet, collect(enumerate(g1[:vlabel])))
+  for (v1,X) in filter(x->x[2] isa ACSet, Base.collect(enumerate(g1[:vlabel])))
     v2 = findfirst(==(X), g2[:vlabel])
     if !isnothing(v2)
       add_vertex!(overlap_g; vlabel=X)
@@ -83,7 +83,7 @@ function merge_graphs(g1,g2)
     end
   end 
   # Merge literal edges
-  for (e1,X) in filter(x->x[2] isa ACSetTransformation, collect(enumerate(g1[:elabel])))
+  for (e1,X) in filter(x->x[2] isa ACSetTransformation, Base.collect(enumerate(g1[:elabel])))
     src1, tgt1 = g1[e1,:src], g1[e1,:tgt]
     e2 = findfirst(==(X), g2[:elabel])
     if !isnothing(e2)
@@ -92,7 +92,7 @@ function merge_graphs(g1,g2)
     end
   end 
   # Merge variable edges 
-  i1, i2 = [collect(filter(x->x isa Int, g[:elabel])) for g in [g1,g2]]
+  i1, i2 = [Base.collect(filter(x->x isa Int, g[:elabel])) for g in [g1,g2]]
   for v in i1 ∩ i2
     e1,e2 = [findfirst(==(v), g[:elabel]) for g in [g1,g2]]
     src1, tgt1 = g1[e1,:src], g1[e1,:tgt]
@@ -142,7 +142,7 @@ commute or to not commute
   commutes::Bool 
   function Commutes(p...; commutes=true)
     !(any(isempty, p) || isempty(p)) || error("Paths cannot be empty")
-    return new(collect(p),commutes)
+    return new(Base.collect(p),commutes)
   end
 end
 
@@ -209,7 +209,7 @@ Exists(e, x; st=True, monic=false) = Quantifier(e,:Exists,x; st, monic)
 """Disjunction of multiple expressions"""
 @struct_hash_equal struct BoolOr <: BoolExpr 
   exprs::Vector{BoolExpr}
-  BoolOr(x...) = new(collect(filter(!=(False),x)))
+  BoolOr(x...) = new(Base.collect(filter(!=(False),x)))
 end
 
 Base.show(io::IO, b::BoolOr) = 
@@ -226,7 +226,7 @@ subexprs(b::BoolOr) = b.exprs
 """Conjunction of multiple expressions"""
 @struct_hash_equal struct BoolAnd <: BoolExpr 
   exprs::Vector{BoolExpr}
-  BoolAnd(x...) = new(collect(filter(!=(True),x)))
+  BoolAnd(x...) = new(Base.collect(filter(!=(True),x)))
 end
 
 Base.show(io::IO, b::BoolAnd) = 
@@ -513,7 +513,7 @@ function getquantifier(d::BoolExpr, e::Int)
   if d isa Quantifier && d.e == e
     quantifier_symbol(d)
   else 
-    qs = collect(filter(!isnothing, getquantifier.(subexprs(d), Ref(e))))
+    qs = Base.collect(filter(!isnothing, getquantifier.(subexprs(d), Ref(e))))
     isempty(qs) ? nothing : only(qs)
   end
 end

--- a/src/rewrite/Inplace.jl
+++ b/src/rewrite/Inplace.jl
@@ -114,7 +114,7 @@ function interp_program!(prog::RewriteProgram, hom::NamedTuple,
   end
   for inst in prog.inits
     fdf = get(hom[inst.attrtype])
-    vals = [getvalue(fdf(v)) for v in sort(collect(dom(fdf)))]
+    vals = [getvalue(fdf(v)) for v in sort(Base.collect(dom(fdf)))]
     m[inst.reg] = @match inst.value begin
       Fresh() => AttrVar(add_part!(state, inst.attrtype))
       Compute(f) => f(vals)

--- a/src/rewrite/PBPO.jl
+++ b/src/rewrite/PBPO.jl
@@ -47,7 +47,7 @@ function of the match morphism.
     # check things match up
     cat = isnothing(cat) ? infer_acset_cat(l) : cat
     S = acset_schema(dom[cat](l))
-    monic = monic === true ? collect(ob(S)) : monic
+    monic = monic === true ? Base.collect(ob(S)) : monic
 
     all([is_natural(x; cat) for x in  [l,r,tl,tk,l′]]) || error("Unnatural")
     dom[cat](l) == dom[cat](r) == dom[cat](tk) || error("bad K")
@@ -255,7 +255,7 @@ function partial_abstract(lg::ACSetTransformation; cat)
       end
     end
     subs[at] = subdict
-    merges[at] = collect(filter(l->!isempty(l), collect(values(mergelist))))
+    merges[at] = Base.collect(filter(l->!isempty(l), Base.collect(values(mergelist))))
   end
   pabs_G = sub_vars(dom[cat](abs_G), subs, merges; cat)
   
@@ -266,7 +266,7 @@ function partial_abstract(lg::ACSetTransformation; cat)
 
   # The quotienting via `sub_vars` means L->PA determined purely by ob components
   to_pabs_init = Dict{Symbol,Vector{Int}}(map(ob(S)) do o
-    o => map(prt(o).(collect(lg[o]))) do i 
+    o => map(prt(o).(Base.collect(lg[o]))) do i 
       pabs_G[o](only(preimage(abs_G[o], i)))
     end
   end)
@@ -319,7 +319,7 @@ function rewrite_match_maps(rule::PBPORule, mα; cat, kw...)
   v, i = var_pullback(Cospan(u′, rule.tk))
   u = compose[cat](invert_iso(i), v)
   abs_r = homomorphism(dom[cat](abs_K), codom[cat](right(rule)); 
-                       initial=Dict(o=>collect(right(rule)[o]) for o in ob(S)))
+                       initial=Dict(o=>Base.collect(right(rule)[o]) for o in ob(S)))
   w, gr = pushout[cat](abs_r, u)
 
   return Dict(:gl=>gl, :u′=>u′, :u=>u, :gr=>gr, :w=>w)
@@ -337,12 +337,12 @@ function get_expr_binding_map(rule::PBPORule, mtch, res; cat)
   comps = Dict(map(attrtypes(acset_schema(X))) do at 
     T = attrtype_type(X, at)
     # match morphism data
-    bound_vars = Vector{T}(getvalue.(collect(get(m[at]))))
+    bound_vars = Vector{T}(getvalue.(Base.collect(get(m[at]))))
     # For each variable in the intermediate rewrite state, determine what 
     # it refers to in the original graph and what in K′ it refers to, too.
     cmp = compose[SkelKleisli(T)](res[:gl][at],ab[at])
-    G_bound_vars = Vector{Any}(getvalue.(collect(get(cmp))))
-    K_bound_vars = getvalue.(collect(get(res[:u′][at])))
+    G_bound_vars = Vector{Any}(getvalue.(Base.collect(get(cmp))))
+    K_bound_vars = getvalue.(Base.collect(get(res[:u′][at])))
     # Functions we associate with K′ variables 
     exprs = haskey(rule.k_exprs,at) ? rule.k_exprs[at] : Dict()
     # Compute a value for each variable in the result

--- a/src/rewrite/SPO.jl
+++ b/src/rewrite/SPO.jl
@@ -42,7 +42,7 @@ function partial_pushout(f::Span, g::Span; cat)
   # Step 1: compute Af ∩ Ag
   glue = Dict{Symbol,Set{Int}}(map(types(S)) do o 
     funs = [o in ob(S) ? x : get(x) for x in [AfA[o], AgA[o]]]
-    o => κ(o)(intersect(Set.(collect.(funs))...))
+    o => κ(o)(intersect(Set.(Base.collect.(funs))...))
   end)
 
   # Step 2: add any elements which are mapped to the same elems by f or g 
@@ -57,7 +57,7 @@ function partial_pushout(f::Span, g::Span; cat)
       end
     end 
   end
-  comps = NamedTuple(Dict([k=>collect(v) for (k,v) in collect(glue)]))
+  comps = NamedTuple(Dict([k=>Base.collect(v) for (k,v) in Base.collect(glue)]))
   fg_A = Subobject(A, comps) |> hom # f ∇ g ↪ A
   fg = dom(fg_A) # f ∇ g
   # Construct scopes Bgf ⊆ B and Cfg ⊆ C
@@ -65,10 +65,10 @@ function partial_pushout(f::Span, g::Span; cat)
   Bgf_B, Cfg_C = map([f,g]) do (mono, ϕ) 
     sub = Dict{Symbol,Vector{Int}}(map(types(S)) do o 
       ϕfun = o ∈ ob(S) ? ϕ[o] : get(ϕ[o])
-      x1 = setdiff(parts(codom(ϕ),o),collect(ϕfun)) # e.g. C - g(A)
+      x1 = setdiff(parts(codom(ϕ),o),Base.collect(ϕfun)) # e.g. C - g(A)
       pre = [preimage(mono[o], fg_A[o](i)) for i in parts(fg,o)]
-      x2 = Set(collect(ϕ[o].(vcat(pre...))))  # e.g. g(f ∇ g)
-      o => sort(collect(x1 ∪ x2))
+      x2 = Set(Base.collect(ϕ[o].(vcat(pre...))))  # e.g. g(f ∇ g)
+      o => sort(Base.collect(x1 ∪ x2))
     end)
 
     hom(Subobject(codom[cat](ϕ), NamedTuple(cascade_subobj(codom[cat](ϕ), sub))))
@@ -81,7 +81,7 @@ function partial_pushout(f::Span, g::Span; cat)
     init = Dict(map(ob(S)) do o 
       o => map(parts(fg, o)) do i 
         c_index = ϕ[o](only(preimage(mono[o],fg_A[o](i))))
-        return findfirst(==(c_index), collect(cod[o]))
+        return findfirst(==(c_index), Base.collect(cod[o]))
       end
     end)
     only(homomorphisms(fg, dom(cod); cat, initial=init))

--- a/src/rewrite/Utils.jl
+++ b/src/rewrite/Utils.jl
@@ -164,8 +164,8 @@ function can_match(r::Rule{T}, m; cat, homsearch=false, initial=Dict()) where T
         return ("Match is not injective", k, m[k])
       end
     end
-    for (k, vs) in collect(initial)
-      errs = check_initial(vs, collect(m[k]))
+    for (k, vs) in Base.collect(initial)
+      errs = check_initial(vs, Base.collect(m[k]))
       if !isempty(errs)
         return ("Initial condition violated", k, errs)
       end
@@ -229,7 +229,7 @@ end
 """Get a list of AttrVar indices which are NOT bound by the I→R morphism"""
 function freevars(r::Rule{T}, attrvar::Symbol) where T
   setdiff(parts(codom(r.R), attrvar), 
-          [v.val for v in collect(r.R[attrvar]) if v isa AttrVar])
+          [v.val for v in Base.collect(r.R[attrvar]) if v isa AttrVar])
 end 
 
 """

--- a/src/schedules/Poly.jl
+++ b/src/schedules/Poly.jl
@@ -59,7 +59,7 @@ each of which has N-many slots."
 List = PMonad{Nothing}(nothing, xs->vcat(last.(xs)...))
 
 # function joinlist(xs)  
-#   collect(enumerate(xs))
+#   Base.collect(enumerate(xs))
 # end
 
 

--- a/src/schedules/Wiring.jl
+++ b/src/schedules/Wiring.jl
@@ -24,15 +24,15 @@ There are also higher level patterns built from these generating morphisms.
 ##################
 """Visualize the data of a CSet homomorphism"""
 str_hom(m::ACSetTransformation) = join([
-  "$k: $(collect(c))" for (k,c) in pairs(components(m))
-  if !isempty(collect(c))], '\n')
+  "$k: $(Base.collect(c))" for (k,c) in pairs(components(m))
+  if !isempty(Base.collect(c))], '\n')
 
 struct Names{T}
   from_name::Dict{String,T}
   to_name::Dict{T,String}
-  Names(d::Dict{String,T}) where T = new{T}(d, Dict([v=>k for (k,v) in collect(d)]))
+  Names(d::Dict{String,T}) where T = new{T}(d, Dict([v=>k for (k,v) in Base.collect(d)]))
 end
-Names(d::Dict) = Names(Dict([string(k)=>v for (k,v) in collect(d)]))
+Names(d::Dict) = Names(Dict([string(k)=>v for (k,v) in Base.collect(d)]))
 Names(;kw...) = Names(Dict([string(k)=>v for (k,v) in pairs(kw)]))
 Base.getindex(n::Names,s::String) = n.from_name[s]
 Base.getindex(n::Names,s::Symbol) = n[string(s)]
@@ -56,13 +56,13 @@ TODO double check that this does not introduce any wire splitting.
 function mk_sched(t_args::NamedTuple,args::NamedTuple,names::Names{T},
                   kw::Union{NamedTuple,AbstractDict}, wd::Expr) where T
   n_trace=length(t_args)
-  os = Dict{Symbol, T}(Symbol(k)=>v for (k,v) in collect(names.from_name))
+  os = Dict{Symbol, T}(Symbol(k)=>v for (k,v) in Base.collect(names.from_name))
   hs = Dict{Symbol, Schedule}(Symbol(k)=>v isa AgentBox ? singleton(v) : v 
                               for (k,v) in pairs(kw))
   P = Presentation(TM)
-  os_ = Dict(v=>add_generator!(P, Ob(TM,k)) for (k,v) in collect(os))
+  os_ = Dict(v=>add_generator!(P, Ob(TM,k)) for (k,v) in Base.collect(os))
 
-  for (k,v) in collect(pairs(hs))
+  for (k,v) in Base.collect(pairs(hs))
     i = (isempty(input_ports(v)) 
         ? munit(TM.Ob) 
         : otimes([os_[ip] for ip in input_ports(v)]))
@@ -241,7 +241,7 @@ function wire_vals(wd::WiringDiagram, i::Int)
   (s,t,_,sval,tval) = wnames[i]
   map(zip(wd.diagram[s], wd.diagram[t])) do (op, ip)
     d = [wd.diagram[op, sval],wd.diagram[ip, tval]]
-    return unique(filter(x->!isnothing(x), collect(values(d))))
+    return unique(filter(x->!isnothing(x), Base.collect(values(d))))
   end 
 end
 

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -14,7 +14,7 @@ h, k = pushout_complement[𝒞](f, g)
 @test force(compose[𝒞](f,g)) == force(compose[𝒞](h,k))
 colim = pushout[𝒞](f,h)
 @test ob(colim) == FinSetInt(6)
-@test allunique(collect(pushout_copair[𝒞](colim, g, k)))
+@test allunique(Base.collect(pushout_copair[𝒞](colim, g, k)))
 
 universal[𝒞](colim, Cospan(g, k))
 

--- a/test/rewrite/PBPO.jl
+++ b/test/rewrite/PBPO.jl
@@ -134,7 +134,7 @@ rule = PBPORule(l,r,tl,tk,l′; lcs = [lc])
 rule_no_condition = PBPORule(l,r,tl,tk,l′)
 
 function get_adherence(m::ACSetTransformation) 
-  root, G = only(collect(m[:V])), codom(m)
+  root, G = only(Base.collect(m[:V])), codom(m)
   descendents = Set()
   queue = [root]
   topological_sort(G) # the following assumes G is a DAG

--- a/test/schedules/Eval.jl
+++ b/test/schedules/Eval.jl
@@ -19,10 +19,10 @@ view_graph(a::Grph, path=tempname()) = view_graph(create(a), path)
 function view_graph(a::ACSetTransformation, path=tempname())
   g = codom(a)
   pg = to_graphviz_property_graph(g)
-  for v in collect(a[:V])
+  for v in Base.collect(a[:V])
     set_vprops!(pg, v, Dict([:style=>"filled",:color=>"red",:fillcolor=>"red"]))
   end
-  for e in collect(a[:E])
+  for e in Base.collect(a[:E])
     set_eprops!(pg, e, Dict([:color=>"red"]))
   end
   gv = to_graphviz(pg)


### PR DESCRIPTION
Currently, tests and docs builds that execute on Julia 1.12 fail:
https://github.com/AlgebraicJulia/AlgebraicRewriting.jl/actions/runs/25817878491

This is due to calls to `collect` being ambiguous.

So, I've prepended calls to `collect` throughout the codebase with `Base.`.

```bash
find . -type f -name "*.jl" -exec sed -i '' 's/collect/Base\.&/g' {} +
```